### PR TITLE
Allow parameters to be specified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "slang-rs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "flate2",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slang-rs"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust bindings for the Slang Verilog parser"

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -32,8 +32,12 @@ pub struct Port {
     pub lsb: usize,
 }
 
-pub fn extract_ports(verilog: &str, ignore_unknown_modules: bool) -> HashMap<String, Vec<Port>> {
-    let result = crate::run_slang(verilog, ignore_unknown_modules).unwrap();
+pub fn extract_ports(
+    verilog: &str,
+    ignore_unknown_modules: bool,
+    parameters: &HashMap<String, String>,
+) -> HashMap<String, Vec<Port>> {
+    let result = crate::run_slang(verilog, ignore_unknown_modules, parameters).unwrap();
     extract_ports_from_value(&result)
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,13 +3,15 @@
 #[cfg(test)]
 mod tests {
     use slang_rs::*;
+    use std::collections::HashMap;
 
     #[test]
     fn test_extract_ports() {
         let verilog = "
         `define M 8
         module foo #(
-            parameter N=11
+            parameter N=11,
+            parameter O=12
         ) (
             input a,
             output [1:0] b,
@@ -22,12 +24,15 @@ mod tests {
             output signed [8:0] i,
             input unsigned [9:0] j,
             output bit [10:0] k,
-            inout wire [0:N] l
+            inout wire [0:N] l,
+            output wire [O-1:0] m
         );
             bar bar_inst(.*);
         endmodule
         ";
-        let definitions = extract_ports(verilog, true);
+        let mut parameters = HashMap::new();
+        parameters.insert("O".to_string(), "42".to_string());
+        let definitions = extract_ports(verilog, true, &parameters);
         println!("{:?}", definitions);
         assert_eq!(
             definitions["foo"],
@@ -103,6 +108,12 @@ mod tests {
                     name: "l".to_string(),
                     msb: 0,
                     lsb: 11
+                },
+                Port {
+                    dir: PortDir::Output,
+                    name: "m".to_string(),
+                    msb: 41,
+                    lsb: 0
                 }
             ]
         );

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -29,6 +29,10 @@ mod tests {
         );
             bar bar_inst(.*);
         endmodule
+        module baz #(
+            parameter P=13
+        );
+        endmodule
         ";
         let mut parameters = HashMap::new();
         parameters.insert("O".to_string(), "42".to_string());


### PR DESCRIPTION
`extract_ports` now has an additional argument, `parameters`, that is a `HashMap<String, String>`. Set parameter values in this argument to override their defaults.