### PR TITLE
Fix CI tests by downloading a prebuilt slang binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,9 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Download Slang
-        uses: actions/download-artifact@v3
-        with:
-          name: slang
-          path: './'
-
-      - name: Make Slang Executable
-        run: chmod +x slang
+        run: |
+          curl -L -o slang "https://github.com/xlsynth/slang-rs/releases/download/ci/slang"
+          chmod +x slang
 
       - name: Run tests
         run: export SLANG_PATH=`realpath slang` && cargo test


### PR DESCRIPTION
CI tests now take 13s instead of 6-7 minutes.