### PR TITLE
Simple fix to support structs and enums with package references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "slang-rs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "num-bigint",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slang-rs"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust bindings for the Slang Verilog parser"

--- a/src/extract/grammar.pest
+++ b/src/extract/grammar.pest
@@ -4,6 +4,8 @@ WHITESPACE = _{ " " | "\t" | "\n" | "\r" }
 
 identifier = @{ (ASCII_ALPHANUMERIC | "_")+ }
 
+full_identifier = @{ (ASCII_ALPHANUMERIC | "_" | ":")+ }
+
 number = @{ ASCII_DIGIT+ }
 
 range = { number ~ ":" ~ number }
@@ -20,9 +22,9 @@ signed_modifier = { "signed" }
 
 logic_type = { ( "logic" | "reg" | "bit" ) ~ signed_modifier? ~ dimensions }
 
-struct_type = { "struct" ~ ("packed")? ~ "{" ~ field_list ~ "}" ~ identifier ~ dimensions }
+struct_type = { "struct" ~ ("packed")? ~ "{" ~ field_list ~ "}" ~ full_identifier ~ dimensions }
 
-enum_type = { "enum" ~ "{" ~ variant_list ~ "}" ~ identifier ~ dimensions }
+enum_type = { "enum" ~ "{" ~ variant_list ~ "}" ~ full_identifier ~ dimensions }
 
 allowed_type = { logic_type | struct_type | enum_type }
 

--- a/src/extract/type_extract.rs
+++ b/src/extract/type_extract.rs
@@ -127,7 +127,7 @@ fn build_struct_type(pair: pest::iterators::Pair<Rule>) -> Type {
                     }
                 }
             }
-            Rule::identifier => {
+            Rule::full_identifier => {
                 name = inner_pair.as_str().to_string();
             }
             Rule::packed_dimensions => {
@@ -172,7 +172,7 @@ fn build_enum_type(pair: pest::iterators::Pair<Rule>) -> Type {
                     }
                 }
             }
-            Rule::identifier => {
+            Rule::full_identifier => {
                 name = inner_pair.as_str().to_string();
             }
             Rule::packed_dimensions => {


### PR DESCRIPTION
Allows `:` to appear in the names for these definitions. Usage of `:` is not validated, however this is already checked by Slang. Perhaps in the future, it might be useful to parse out package references (i.e., splitting on `::`).