### PR TITLE
Fix a bug with array dimensions + add a function to get the width of a type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "slang-rs"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "num-bigint",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slang-rs"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust bindings for the Slang Verilog parser"


### PR DESCRIPTION
The bug with array dimensions was that array dimensions (packed and unpacked) were being ignored for arrays of structs and enums.