### PR TITLE
Add extract_modules function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "slang-rs"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "num-bigint",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slang-rs"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust bindings for the Slang Verilog parser"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use std::fs::{self, write};
 use std::process::Command;
 
 mod extract;
-pub use extract::{extract_ports, Field, Port, PortDir, Range, Type, Variant};
+pub use extract::{extract_modules, extract_ports, Field, Port, PortDir, Range, Type, Variant};
 
 #[derive(Debug)]
 pub struct SlangConfig<'a> {


### PR DESCRIPTION
Returns a list of modules (as string names) defined in the given source file(s)