### PR TITLE
Add rocky8 build-and-release.

### DIFF
--- a/.github/workflows/slang.yml
+++ b/.github/workflows/slang.yml
@@ -35,3 +35,33 @@ jobs:
         with:
           name: slang
           path: 'source/build/bin/slang'
+
+  build-rocky8:
+    runs-on: ubuntu-latest
+    container: rockylinux:8
+
+    steps:
+      - name: Download Slang Release
+        run: |
+          curl -L -o source.tar.gz "https://github.com/MikePopoloski/slang/archive/refs/tags/v6.0.tar.gz"
+
+      - name: Extract Tarball
+        run: |
+          mkdir source
+          tar -xzf source.tar.gz -C source --strip-components=1
+
+      - name: Install Dependencies
+        run: |
+          yum install -y gcc openssl-devel libffi-devel make cmake curl
+
+      - name: Build Slang
+        working-directory: source
+        run: |
+          cmake -B build
+          cmake --build build -j8
+
+      - name: Upload Binary Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: slang-rocky8
+          path: 'source/build/bin/slang'

--- a/.github/workflows/slang.yml
+++ b/.github/workflows/slang.yml
@@ -41,6 +41,13 @@ jobs:
     container: rockylinux:8
 
     steps:
+      - name: Install Clang-17
+        run: |
+          dnf install -y llvm-toolset
+
+      - name: Note Clang version
+        run: clang-17 --version
+
       - name: Download Slang Release
         run: |
           curl -L -o source.tar.gz "https://github.com/MikePopoloski/slang/archive/refs/tags/v6.0.tar.gz"
@@ -57,8 +64,8 @@ jobs:
       - name: Build Slang
         working-directory: source
         run: |
-          cmake -B build
-          cmake --build build -j8
+          CC=clang-17 CXX=clang++-17 cmake -B build
+          CC=clang-17 CXX=clang++-17 cmake --build build -j8
 
       - name: Upload Binary Artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+*.sw[opqrs]


### PR DESCRIPTION
This is required for CI of dependent packages on this platform, since this crate pulls slang.

Assuming ubuntu 20.04 means we assume too recent a GLIBC version for rocky8 builds to succeed.