### PR TITLE
Option to skip `<error>` types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "slang-rs"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "num-bigint",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slang-rs"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust bindings for the Slang Verilog parser"

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -63,6 +63,13 @@ pub fn extract_ports_from_value(
                                 let port_name = instance_member["name"].as_str().unwrap();
                                 let direction = instance_member["direction"].as_str().unwrap();
                                 let type_str = instance_member["type"].as_str().unwrap();
+                                if type_str == "<error>" {
+                                    if skip_unsupported {
+                                        continue;
+                                    } else {
+                                        panic!("Found \"<error>\" type in Slang JSON output.");
+                                    }
+                                }
                                 let ty = match parse_type_definition(type_str) {
                                     Ok(ty) => ty,
                                     Err(e) => {


### PR DESCRIPTION
`skip_unsupported` now skips over signal types set to `<error>`