### PR TITLE
Add timescale option to SlangConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "slang-rs"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "num-bigint",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slang-rs"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust bindings for the Slang Verilog parser"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub struct SlangConfig<'a> {
     pub libdirs: &'a [&'a str],
     pub libexts: &'a [&'a str],
     pub ignore_unknown_modules: bool,
+    pub timescale: Option<&'a str>,
 }
 
 impl<'a> Default for SlangConfig<'a> {
@@ -32,6 +33,7 @@ impl<'a> Default for SlangConfig<'a> {
             libdirs: &[],
             libexts: &[],
             ignore_unknown_modules: true,
+            timescale: None,
         }
     }
 }
@@ -110,6 +112,11 @@ pub fn run_slang(cfg: &SlangConfig) -> Result<Value, Box<dyn std::error::Error>>
     for libext in cfg.libexts.iter() {
         args.push("-Y");
         args.push(libext);
+    }
+
+    if let Some(timescale) = cfg.timescale {
+        args.push("--timescale");
+        args.push(timescale);
     }
 
     for source in cfg.sources.iter() {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -671,4 +671,50 @@ endmodule
 
         assert_eq!(modules, vec!["A", "B", "C", "D"]);
     }
+
+    #[test]
+    fn test_timescale_option() {
+        let verilog_a = str2tmpfile(
+            "
+module A(
+    input clk
+);
+    B b();
+endmodule
+",
+        )
+        .unwrap();
+
+        let verilog_b = str2tmpfile(
+            "
+`timescale 1ns/1ps
+module B;
+endmodule
+",
+        )
+        .unwrap();
+
+        let cfg = SlangConfig {
+            sources: &[
+                verilog_b.path().to_str().unwrap(),
+                verilog_a.path().to_str().unwrap(),
+            ],
+            tops: &["A"],
+            timescale: Some("1ns/1ps"),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            extract_ports(&cfg, false)["A"],
+            vec![Port {
+                dir: PortDir::Input,
+                name: "clk".to_string(),
+                ty: Type::Logic {
+                    signed: false,
+                    packed_dimensions: vec![],
+                    unpacked_dimensions: vec![]
+                },
+            }]
+        );
+    }
 }


### PR DESCRIPTION
`SlangConfig` now has an optional `timescale` input - this can be helpful when parsing a code base where some modules have timescales and others don't.