### PR TITLE
`ignore_protected` feature

### DIFF
--- a/.github/workflows/slang.yml
+++ b/.github/workflows/slang.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Download Slang Release
         run: |
-          curl -L -o source.tar.gz "https://github.com/MikePopoloski/slang/archive/refs/tags/v6.0.tar.gz"
+          curl -L -o source.tar.gz "https://github.com/MikePopoloski/slang/archive/refs/tags/v7.0.tar.gz"
 
       - name: Extract Tarball
         run: |
@@ -55,7 +55,7 @@ jobs:
 
       - name: Download Slang Release
         run: |
-          curl -L -o source.tar.gz "https://github.com/MikePopoloski/slang/archive/refs/tags/v6.0.tar.gz"
+          curl -L -o source.tar.gz "https://github.com/MikePopoloski/slang/archive/refs/tags/v7.0.tar.gz"
 
       - name: Extract Tarball
         run: |

--- a/.github/workflows/slang.yml
+++ b/.github/workflows/slang.yml
@@ -46,12 +46,12 @@ jobs:
           dnf install -y python3 python3-devel
           dnf install -y gcc openssl-devel libffi-devel make cmake curl git
 
-      - name: Install Clang-17
+      - name: Install Clang-18
         run: |
           dnf install -y llvm-toolset
 
       - name: Note Clang version
-        run: clang-17 --version
+        run: clang-18 --version
 
       - name: Download Slang Release
         run: |
@@ -65,8 +65,8 @@ jobs:
       - name: Build Slang
         working-directory: source
         run: |
-          CC=clang-17 CXX=clang++-17 cmake -B build
-          CC=clang-17 CXX=clang++-17 cmake --build build -j8
+          CC=clang-18 CXX=clang++-18 cmake -B build
+          CC=clang-18 CXX=clang++-18 cmake --build build -j8
 
       - name: Upload Binary Artifact
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "slang-rs"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "num-bigint",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slang-rs"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust bindings for the Slang Verilog parser"

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -717,4 +717,62 @@ endmodule
             }]
         );
     }
+
+    #[test]
+    fn test_protected() {
+        let verilog = str2tmpfile(
+            "
+        module foo(
+            input a
+        );
+            `protected
+            asdf
+            `endprotected
+        endmodule",
+        )
+        .unwrap();
+
+        let cfg = SlangConfig {
+            sources: &[verilog.path().to_str().unwrap()],
+            ..Default::default()
+        };
+
+        let definitions = extract_ports(&cfg, false);
+        assert_eq!(
+            definitions["foo"],
+            vec![Port {
+                dir: PortDir::Input,
+                name: "a".to_string(),
+                ty: Type::Logic {
+                    signed: false,
+                    packed_dimensions: vec![],
+                    unpacked_dimensions: vec![],
+                },
+            }]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown macro")]
+    fn test_protected_panic() {
+        let verilog = str2tmpfile(
+            "
+        module foo(
+            input a
+        );
+            `protected
+            asdf
+            `endprotected
+        endmodule",
+        )
+        .unwrap();
+
+        let cfg = SlangConfig {
+            sources: &[verilog.path().to_str().unwrap()],
+            ignore_protected: false,
+            ..Default::default()
+        };
+
+        extract_ports(&cfg, false);
+    }
 }


### PR DESCRIPTION
This PR provides a feature for ignoring `protected` sections of Verilog code via an existing Slang feature. The option is called `ignore_protected` in `SlangConfig` and is `true` by default. All `protected`-related warnings are disabled when `ignore_protected` is set.