### PR TITLE
Fix bug in handling negative indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "slang-rs"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "num-bigint",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slang-rs"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust bindings for the Slang Verilog parser"

--- a/src/extract/grammar.pest
+++ b/src/extract/grammar.pest
@@ -6,9 +6,13 @@ identifier = @{ (ASCII_ALPHANUMERIC | "_")+ }
 
 full_identifier = @{ (ASCII_ALPHANUMERIC | "_" | ":")+ }
 
-number = @{ ASCII_DIGIT+ }
+negative_sign = { "-" }
 
-range = { number ~ ":" ~ number }
+non_negative_integer = { ASCII_DIGIT+ }
+
+integer = { negative_sign? ~ non_negative_integer }
+
+range = { integer ~ ":" ~ integer }
 
 packed_dimension = { "[" ~ range ~ "]" }
 
@@ -34,9 +38,7 @@ field = { allowed_type ~ identifier }
 
 field_list = { field ~ (";" ~ field)* ~ (";")? }
 
-negative_sign = { "-" }
-
-verilog_decimal = { negative_sign? ~ number ~ "'" ~ ("s")? ~ "d" ~ number }
+verilog_decimal = { negative_sign? ~ non_negative_integer ~ "'" ~ ("s")? ~ "d" ~ non_negative_integer }
 
 variant = { identifier ~ "=" ~ verilog_decimal }
 

--- a/src/extract/type_extract.rs
+++ b/src/extract/type_extract.rs
@@ -46,8 +46,8 @@ pub struct Field {
 
 #[derive(Debug, PartialEq)]
 pub struct Range {
-    pub msb: usize,
-    pub lsb: usize,
+    pub msb: i32,
+    pub lsb: i32,
 }
 
 #[derive(Debug, PartialEq)]
@@ -104,7 +104,7 @@ impl Type {
         Ok(self
             .packed_dimensions()
             .iter()
-            .map(|Range { msb, lsb }| msb - lsb + 1)
+            .map(|Range { msb, lsb }| ((msb - lsb).abs() + 1) as usize)
             .product())
     }
 
@@ -363,8 +363,8 @@ fn build_variant(pair: pest::iterators::Pair<Rule>) -> Variant {
 
 fn build_range(pair: pest::iterators::Pair<Rule>) -> Range {
     let mut inner = pair.into_inner();
-    let msb = inner.next().unwrap().as_str().parse::<usize>().unwrap();
-    let lsb = inner.next().unwrap().as_str().parse::<usize>().unwrap();
+    let msb = inner.next().unwrap().as_str().parse::<i32>().unwrap();
+    let lsb = inner.next().unwrap().as_str().parse::<i32>().unwrap();
     Range { msb, lsb }
 }
 


### PR DESCRIPTION
`slang-rs` did not previously allow ranges to have negative indices; this PR fixes that issue.