### PR TITLE
Add publish action + various checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# adapted from https://github.com/xlsynth/xlsynth-crate/blob/main/.github/workflows/ci.yml
+
 name: Rust CI
 
 on:
@@ -10,12 +12,42 @@ on:
       - main
 
 jobs:
-  test:
-
+  # -----------------------------------------------------------
+  # 1) Lint-check / pre-commit gate
+  # -----------------------------------------------------------
+  lint-check:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Python + pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+
+      - name: Run pre-commit
+        env:
+          SKIP: no-commit-to-branch
+        run: |
+          pre-commit install
+          pre-commit run --all-files
+
+  # -----------------------------------------------------------
+  # 2) Build/test
+  # -----------------------------------------------------------
+  build-and-test:
+    needs: [lint-check]  # Ensure lint checks pass first
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]  # TODO: add more OSes in the future
+      fail-fast: false
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# adapted from https://github.com/xlsynth/xlsynth-crate/blob/main/.github/workflows/publish.yml
+
+name: Publish to crates.io
+
+on:
+  push:
+    tags:
+      - 'v*' # This will trigger the workflow on version tags like v1.0.0, v0.1.0, etc.
+
+jobs:
+  publish:
+    runs-on: macos-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Validate version matches
+      run: |
+        # GITHUB_REF will be something like "refs/tags/v0.0.57"
+        # We'll strip off the "refs/tags/" part, leaving "v0.0.57".
+        VERSION="${GITHUB_REF#refs/tags/}"
+
+        # Now invoke the Python script, passing the version.
+        python check_version_is.py "$VERSION"
+
+    - name: Download Slang
+      run: |
+        curl -L -o slang "https://github.com/xlsynth/slang-rs/releases/download/ci/slang"
+        chmod +x slang
+
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Cache Cargo registry
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-registry-
+
+    - name: Cache Cargo index
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-index-
+
+    - name: Build and test
+      run: |
+        export SLANG_PATH=`realpath slang`
+        cargo test
+
+    - name: Publish slang-rs to crates.io
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      run: |
+        cargo publish --token $CARGO_REGISTRY_TOKEN

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# adapted from:
+# * https://github.com/xlsynth/xlsynth-crate/blob/main/.pre-commit-config.yaml
+# * https://github.com/xlsynth/bedrock-rtl/blob/main/.pre-commit-config.yaml
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-symlinks
+      - id: destroyed-symlinks
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-ast
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: detect-private-key
+      - id: debug-statements
+      - id: mixed-line-ending
+      - id: no-commit-to-branch
+        args: ['--branch', 'main']
+  - repo: local
+    hooks:
+      - id: rustfmt
+        name: rustfmt
+        description: Check if all files follow the rustfmt style
+        entry: cargo fmt --all -- --check --color always
+        language: system
+        pass_filenames: false
+
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.17  # Use a version that supports Python 3.8
+    hooks:
+    - id: mdformat

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +83,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +128,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "cpufeatures"
@@ -67,6 +155,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9fb4d13a1be2b58f14d60adba57c9834b78c62fd86c3e76a148f732686e9265"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.80+curl-8.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f7df2eac63200c3ab25bde3b2268ef2ee56af3d238e76d61f01c3c49bff734"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +199,29 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
 
 [[package]]
 name = "errno"
@@ -118,6 +259,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,10 +283,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
+name = "libz-sys"
+version = "1.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "log"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "memchr"
@@ -171,9 +342,27 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "pest"
@@ -219,6 +408,12 @@ dependencies = [
  "pest",
  "sha2",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "proc-macro2"
@@ -296,6 +491,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,18 +569,34 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slang-rs"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
+ "cargo_metadata",
+ "curl",
+ "env_logger",
+ "log",
  "num-bigint",
  "num-traits",
  "pest",
  "pest_derive",
  "regex",
+ "semver",
  "serde",
  "serde_json",
  "serde_stacker",
  "tempfile",
+ "toml",
  "which",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -428,6 +657,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +682,18 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slang-rs"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust bindings for the Slang Verilog parser"
@@ -19,3 +19,11 @@ pest_derive = "2.1"
 num-bigint = "0.4.3"
 num-traits = "0.2"
 which = "7.0.0"
+
+[dev-dependencies]
+cargo_metadata = "0.18"
+curl = "0.4"
+log = "0.4"
+toml = "0.5"
+semver = "1.0"
+env_logger = "0.11"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # slang-rs
+
 Parse SystemVerilog with Slang using a Rust API.
 
 Note: the API is currently under development and is subject to frequent changes.
@@ -55,4 +56,26 @@ cd slang-rs
 
 ```shell
 cargo test
+```
+
+## Development
+
+We use [pre-commit](https://pre-commit.com/) as part of our CI pipeline.
+
+If you haven't already installed `pre-commit`, you can do so with:
+
+```shell
+pip install pre-commit
+```
+
+Then install the pre-commit hooks for this repository with:
+
+```shell
+pre-commit install
+```
+
+The pre-commit hooks will run automatically when you attempt to commit code. You can also run pre-commit checks on-demand with:
+
+```shell
+pre-commit run
 ```

--- a/check_version_is.py
+++ b/check_version_is.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+# from https://github.com/xlsynth/xlsynth-crate/blob/main/check_version_is.py
+
+import sys
+import re
+import os
+
+if len(sys.argv) < 2:
+    print("Usage: check_version_is.py <version>")
+    sys.exit(1)
+
+# The argument might be e.g. "v0.0.57" or "0.0.57"
+arg_version = sys.argv[1]
+print(f"Argument version: {arg_version!r}")
+
+# If you expect the script to always receive e.g. "v0.0.57",
+# you can strip the leading 'v' here:
+tag_version = arg_version.lstrip('v')
+print(f"Tag version:       {tag_version!r}")
+
+# Read the version from xlsynth-sys/Cargo.toml
+toml_path = os.path.join("xlsynth-sys", "Cargo.toml")
+with open(toml_path, "r", encoding="utf-8") as f:
+    cargo_toml = f.read()
+
+print(f"Cargo.toml: {cargo_toml!r}")
+
+# Use a regex to extract the version from a line like: version = "0.0.57"
+match = re.search(r'^version\s*=\s*"([^"]+)"', cargo_toml, re.MULTILINE)
+if not match:
+    print("Error: Could not find a valid `version = \"...\"` line in xlsynth-sys/Cargo.toml.")
+    sys.exit(1)
+
+cargo_version = match.group(1)
+
+print(f"Tag version:       {tag_version!r}")
+print(f"Cargo.toml version: {cargo_version!r}")
+
+# Compare the extracted version with the tag version
+if cargo_version != tag_version:
+    print(
+        f"Error: version mismatch. "
+        f"Tag is {tag_version!r}, but xlsynth-sys/Cargo.toml is {cargo_version!r}."
+    )
+    sys.exit(1)
+
+print("Success: Tag version matches Cargo.toml version.")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,8 +176,7 @@ pub fn run_slang(cfg: &SlangConfig) -> Result<Value, Box<dyn std::error::Error>>
     // https://docs.rs/serde_json/latest/serde_json/struct.Deserializer.html#method.disable_recursion_limit
     json_deserializer.disable_recursion_limit();
 
-    let stacked_deserializer =
-        serde_stacker::Deserializer::new(&mut json_deserializer);
+    let stacked_deserializer = serde_stacker::Deserializer::new(&mut json_deserializer);
     let json_value = Value::deserialize(stacked_deserializer)?;
 
     Ok(json_value)

--- a/tests/spdx_test.rs
+++ b/tests/spdx_test.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// adapted from https://github.com/xlsynth/xlsynth-crate/blob/main/test-helpers/tests/spdx_test.rs
+
+use cargo_metadata::MetadataCommand;
+use std::fs;
+use std::io::{self, BufRead};
+use std::path::{Path, PathBuf};
+
+fn check_spdx_identifier(file_path: &Path) -> bool {
+    let filename = file_path.file_name().unwrap().to_str().unwrap();
+    let comment_prefix = if filename.ends_with(".yml")
+        || filename.ends_with(".yaml")
+        || filename.ends_with(".py")
+        || filename.ends_with(".sh")
+    {
+        "#"
+    } else {
+        "//"
+    };
+    let expect_shebang = filename.ends_with(".py") || filename.ends_with(".sh");
+    let expected_spdx_identifier = format!("{comment_prefix} SPDX-License-Identifier: Apache-2.0");
+
+    let file = fs::File::open(file_path).unwrap();
+    let reader = io::BufReader::new(file);
+    let mut lines = reader.lines();
+    let ok = if expect_shebang {
+        let first_line = lines.next().unwrap().unwrap();
+        if first_line.starts_with("#!") {
+            lines
+                .next()
+                .unwrap()
+                .unwrap()
+                .starts_with(&expected_spdx_identifier)
+        } else {
+            first_line.starts_with(&expected_spdx_identifier)
+        }
+    } else {
+        let first_line = lines.next();
+        if let Some(Ok(line)) = first_line {
+            line.starts_with(&expected_spdx_identifier)
+        } else {
+            false
+        }
+    };
+    if ok {
+        println!("Found SPDX identifier in file: {:?}", file_path);
+    } else {
+        eprintln!("Missing SPDX identifier in file: {:?}", file_path);
+    }
+    ok
+}
+
+fn find_missing_spdx_files(root: &Path) -> Vec<PathBuf> {
+    let mut missing_spdx_files = Vec::new();
+    let mut dir_worklist: Vec<PathBuf> = vec![root.into()];
+
+    loop {
+        let dir = match dir_worklist.pop() {
+            Some(dir) => dir,
+            None => break,
+        };
+        for entry in fs::read_dir(dir).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+
+            if path.is_dir() {
+                // Exclude directories that should not be checked
+                if entry.file_name() != "target"
+                    && entry.file_name() != ".git"
+                    && entry.file_name() != "xlsynth_tools"
+                {
+                    println!("Adding to directory worklist: {:?}", path);
+                    dir_worklist.push(path.clone());
+                }
+                continue;
+            }
+
+            // For golden comparison files (i.e. ones we compare to literally for code
+            // generation facilities) we don't require SPDX identifiers.
+            if path.as_os_str().to_str().unwrap().ends_with(".golden.sv") {
+                continue;
+            }
+
+            if path.file_name().unwrap().to_str().unwrap() == "estimator_model.proto" {
+                continue;
+            }
+
+            if let Some(extension) = path.extension() {
+                if extension == "md"
+                    || extension == "lock"
+                    || extension == "toml"
+                    || extension == "supp"
+                {
+                    continue;
+                }
+                // Check all source files, not just Rust files
+                if !check_spdx_identifier(&path) {
+                    missing_spdx_files.push(path);
+                }
+            }
+        }
+    }
+    missing_spdx_files
+}
+
+#[test]
+fn test_finds_rust_file_missing_spdx_in_tempdir() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir_path = temp_dir.path();
+
+    // Write one file that does have the SPDX identifier.
+    let has_spdx_file = temp_dir_path.join("has_spdx.rs");
+    fs::write(has_spdx_file, "// SPDX-License-Identifier: Apache-2.0\n").unwrap();
+
+    // Write one file that does not have the SPDX identifier.
+    let missing_spdx_file = temp_dir_path.join("missing_spdx.rs");
+    fs::write(missing_spdx_file.clone(), "").unwrap();
+
+    let missing_spdx_files = find_missing_spdx_files(temp_dir_path);
+    assert_eq!(missing_spdx_files.len(), 1);
+    assert!(missing_spdx_files.contains(&missing_spdx_file));
+}
+
+#[test]
+fn check_all_rust_files_for_spdx() {
+    // Use cargo_metadata to get the workspace root
+    let metadata = MetadataCommand::new().exec().unwrap();
+    let workspace_dir = metadata.workspace_root;
+    let missing_spdx_files = find_missing_spdx_files(workspace_dir.as_std_path());
+    assert!(
+        missing_spdx_files.is_empty(),
+        "The following files are missing SPDX identifiers: {:?}",
+        missing_spdx_files
+    );
+}

--- a/tests/version_test.rs
+++ b/tests/version_test.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Test that the current package version reflected in Cargo.toml is more than
+//! the released version -- this help make sure we bump the version
+//! appropriately after a release is performed.
+//!
+//! This is done for all released crates in the workspace.
+// from https://github.com/xlsynth/xlsynth-crate/blob/main/test-helpers/tests/version_test.rs
+
+use curl::easy::Easy;
+
+const USER_AGENT: &str = "slang_rs_crate_unit_test";
+
+fn get_workspace_root() -> std::path::PathBuf {
+    let workspace_dir = cargo_metadata::MetadataCommand::new()
+        .exec()
+        .unwrap()
+        .workspace_root;
+    workspace_dir.into()
+}
+
+/// Fetches the latest version of a crate named `crate_name` from crates.io.
+fn fetch_latest_version(crate_name: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let url = format!("https://crates.io/api/v1/crates/{}", crate_name);
+    let mut data = Vec::new();
+    let mut easy = Easy::new();
+    easy.url(&url)?;
+    easy.useragent(USER_AGENT)?;
+    {
+        let mut transfer = easy.transfer();
+        transfer.write_function(|new_data| {
+            data.extend_from_slice(new_data);
+            Ok(new_data.len())
+        })?;
+        transfer.perform()?;
+    }
+
+    let response: serde_json::Value = serde_json::from_slice(&data)?;
+    log::debug!("Response: {:?}", response);
+    let newest_version = response["crate"]["newest_version"].as_str();
+    let latest_version = newest_version
+        .ok_or(format!(
+            "Failed to parse latest version: {:?}",
+            newest_version
+        ))?
+        .to_string();
+    Ok(latest_version)
+}
+
+/// Fetches the local version of a package given the path to a `Cargo.toml`
+/// file.
+fn fetch_local_version(dirpath: &std::path::PathBuf) -> Result<String, Box<dyn std::error::Error>> {
+    let cargo_toml = std::fs::read_to_string(dirpath.join("Cargo.toml"))?;
+    let cargo_toml: toml::Value = toml::from_str(&cargo_toml)?;
+    let version = cargo_toml["package"]["version"]
+        .as_str()
+        .ok_or(format!(
+            "Failed to parse local version: {}",
+            cargo_toml["package"]["version"]
+        ))?
+        .to_string();
+    Ok(version)
+}
+
+fn validate_local_version_gt_released(
+    crate_name: &str,
+    workspace_path: &std::path::PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let latest_version = fetch_latest_version(crate_name)?;
+    let local_version = fetch_local_version(workspace_path)?;
+
+    let local_semver = semver::Version::parse(&local_version)?;
+    let latest_semver = semver::Version::parse(&latest_version)?;
+
+    log::info!(
+        "crate: {} local_version: {} released_version: {}",
+        crate_name,
+        local_version,
+        latest_version
+    );
+
+    if local_semver <= latest_semver {
+        // Technically we're abusing io::Error a bit here just to avoid creating a whole
+        // new error type.
+        Err(Box::new(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!(
+                "Local version {} is not greater than the latest version {}",
+                local_version, latest_version
+            ),
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+#[test]
+fn test_slang_rs_crate_version() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    validate_local_version_gt_released("slang_rs", &get_workspace_root()).unwrap();
+}


### PR DESCRIPTION
These are adapted from [xlsynth-crate](https://github.com/xlsynth/xlsynth-crate) and [bedrock-rtl](https://github.com/xlsynth/bedrock-rtl):
* Automatically publish to [crates.io](https://crates.io) when a `v*` tag is pushed.
* Check to make sure the `Cargo.toml` version is ahead of the crates.io version
* Check to make sure that there is an SPDX license comment at the top of each page
* Run pre-commit checks to catch file formatting issues.