### PR TITLE
Added build.rs to build with CMake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +581,7 @@ name = "slang-rs"
 version = "0.16.0"
 dependencies = [
  "cargo_metadata",
+ "cmake",
  "curl",
  "env_logger",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ num-bigint = "0.4.3"
 num-traits = "0.2"
 which = "7.0.0"
 
+[build-dependencies]
+cmake = "0.1.54"
+
 [dev-dependencies]
 cargo_metadata = "0.18"
 curl = "0.4"

--- a/README.md
+++ b/README.md
@@ -4,42 +4,19 @@ Parse SystemVerilog with Slang using a Rust API.
 
 Note: the API is currently under development and is subject to frequent changes.
 
-## Prerequisite
-
-First install the Slang parser. We recommend building it from source.
-
-```shell
-curl -LO "https://github.com/MikePopoloski/slang/archive/refs/tags/v6.0.tar.gz"
-```
-
-```shell
-tar xzvf v6.0.tar.gz
-```
-
-```shell
-cd slang-6.0
-```
-
-```shell
-cmake -B build
-```
-
-```shell
-cmake --build build -j8
-```
-
-This will take a few minutes. Then set an environment variable to specify the location of the Slang binary:
-
-```shell
-export SLANG_PATH=`realpath build/bin/slang`
-```
-
 ## Installation
 
 Install Rust if you don't have it already:
 
 ```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Also install cmake if it is not already installed:
+
+Ubuntu:
+```shell
+sudo apt-get install cmake
 ```
 
 Then clone this repository:

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,7 @@
-// build.rs
 use std::{
 	env,
 	fs,
-	path::{Path, PathBuf},
+	path::{PathBuf},
 	process::Command,
 };
 
@@ -10,10 +9,13 @@ fn main() {
 	// Instruct Cargo to re-run this script if build.rs itself changes.
 	println!("cargo:rerun-if-changed=build.rs");
 
-	// Define the desired version and tarball URL for Slang.
-	const SLANG_VERSION: &str = "v6.0";
-	const SLANG_TARBALL_URL: &str =
-		"https://github.com/MikePopoloski/slang/archive/refs/tags/v6.0.tar.gz";
+	// Define the desired version for Slang.
+	const SLANG_VERSION: &str = "8.0";
+	// Compute the tarball URL at runtime.
+	let slang_tarball_url = format!(
+		"https://github.com/MikePopoloski/slang/archive/refs/tags/v{}.tar.gz",
+		SLANG_VERSION
+	);
 
 	// Get the OUT_DIR to download and extract the source.
 	let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
@@ -22,67 +24,39 @@ fn main() {
 
 	// If the Slang source directory does not exist, download and extract it.
 	if !slang_src_dir.exists() {
-		println!(
-			"Downloading Slang {} from {}",
-			SLANG_VERSION, SLANG_TARBALL_URL
-		);
+		println!("Downloading Slang {} from {}", SLANG_VERSION, slang_tarball_url);
 		// Define the path where the tarball will be saved.
-		let tarball_path = out_dir.join("slang.tar.gz");
-
+		let tarball_path = out_dir.join(format!("{SLANG_VERSION}.tar.gz"));
 		// Download the tarball using the "curl" command.
 		let status = Command::new("curl")
 			.args(&["-L", "-o"])
 			.arg(tarball_path.to_str().unwrap())
-			.arg(SLANG_TARBALL_URL)
+			.arg(&slang_tarball_url)
 			.status()
 			.expect("Failed to execute curl to download Slang tarball");
-		assert!(
-			status.success(),
-			"curl failed to download Slang tarball: {:?}",
-			status
-		);
-
+		assert!(status.success(), "curl failed to download Slang tarball: {:?}", status);
 		// Extract the tarball using the "tar" command.
-		// This will extract the archive into OUT_DIR; typically the directory
-		// created will be "slang-6.0".
 		let status = Command::new("tar")
-			.args(&[
-				"-xzf",
-				tarball_path.to_str().unwrap(),
-				"-C",
-				out_dir.to_str().unwrap(),
-			])
+			.args(&["-xzf", tarball_path.to_str().unwrap(), "-C", out_dir.to_str().unwrap()])
 			.status()
 			.expect("Failed to execute tar command to extract Slang tarball");
-		assert!(
-			status.success(),
-			"tar command failed to extract Slang tarball: {:?}",
-			status
-		);
-
-		// The tarball typically extracts to a folder named "slang-6.0".
-		// Rename that folder to "slang-src"
-		let extracted_dir = out_dir.join("slang-6.0");
+		assert!(status.success(), "tar command failed to extract Slang tarball: {:?}", status);
+		// Rename the extracted folder to "slang-src"
+		let extracted_dir = out_dir.join(format!("slang-{SLANG_VERSION}"));
 		fs::rename(&extracted_dir, &slang_src_dir)
 			.expect("Failed to rename extracted Slang folder");
 	} else {
 		println!("Using cached Slang source at {:?}", slang_src_dir);
 	}
 
-	// Build Slang using the cmake crate.
-	// You can pass extra definitions as needed (for example, to disable tests).
+	// Build Slang using the cmake crate with cxx17
 	let dst: PathBuf = cmake::Config::new(&slang_src_dir)
-		.define("BUILD_TESTS", "OFF")
-		// Add additional .define(...) calls if you need to customize the build.
+		.define("BUILD_TESTS", "OFF")        // disable tests as before
+		.define("CMAKE_CXX_STANDARD", "17")    // force C++17
 		.build();
 
-	// In this example, we assume that the built binary ends up under ${dst}/bin/slang.
+	// In this example, the built binary is expected under ${dst}/bin/slang.
 	let slang_bin = dst.join("bin").join("slang");
-
-	// Print a message (a Cargo "directive") so that later your Rust code
-	// can retrieve the binary path from the SLANG_PATH environment variable.
 	println!("cargo:rustc-env=SLANG_PATH={}", slang_bin.display());
-
-	// Optionally, print a warning if desired:
 	println!("cargo:warning=Using built Slang binary at: {}", slang_bin.display());
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,88 @@
+// build.rs
+use std::{
+	env,
+	fs,
+	path::{Path, PathBuf},
+	process::Command,
+};
+
+fn main() {
+	// Instruct Cargo to re-run this script if build.rs itself changes.
+	println!("cargo:rerun-if-changed=build.rs");
+
+	// Define the desired version and tarball URL for Slang.
+	const SLANG_VERSION: &str = "v6.0";
+	const SLANG_TARBALL_URL: &str =
+		"https://github.com/MikePopoloski/slang/archive/refs/tags/v6.0.tar.gz";
+
+	// Get the OUT_DIR to download and extract the source.
+	let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+	// We will extract the Slang source into OUT_DIR/slang-src.
+	let slang_src_dir = out_dir.join("slang-src");
+
+	// If the Slang source directory does not exist, download and extract it.
+	if !slang_src_dir.exists() {
+		println!(
+			"Downloading Slang {} from {}",
+			SLANG_VERSION, SLANG_TARBALL_URL
+		);
+		// Define the path where the tarball will be saved.
+		let tarball_path = out_dir.join("slang.tar.gz");
+
+		// Download the tarball using the "curl" command.
+		let status = Command::new("curl")
+			.args(&["-L", "-o"])
+			.arg(tarball_path.to_str().unwrap())
+			.arg(SLANG_TARBALL_URL)
+			.status()
+			.expect("Failed to execute curl to download Slang tarball");
+		assert!(
+			status.success(),
+			"curl failed to download Slang tarball: {:?}",
+			status
+		);
+
+		// Extract the tarball using the "tar" command.
+		// This will extract the archive into OUT_DIR; typically the directory
+		// created will be "slang-6.0".
+		let status = Command::new("tar")
+			.args(&[
+				"-xzf",
+				tarball_path.to_str().unwrap(),
+				"-C",
+				out_dir.to_str().unwrap(),
+			])
+			.status()
+			.expect("Failed to execute tar command to extract Slang tarball");
+		assert!(
+			status.success(),
+			"tar command failed to extract Slang tarball: {:?}",
+			status
+		);
+
+		// The tarball typically extracts to a folder named "slang-6.0".
+		// Rename that folder to "slang-src"
+		let extracted_dir = out_dir.join("slang-6.0");
+		fs::rename(&extracted_dir, &slang_src_dir)
+			.expect("Failed to rename extracted Slang folder");
+	} else {
+		println!("Using cached Slang source at {:?}", slang_src_dir);
+	}
+
+	// Build Slang using the cmake crate.
+	// You can pass extra definitions as needed (for example, to disable tests).
+	let dst: PathBuf = cmake::Config::new(&slang_src_dir)
+		.define("BUILD_TESTS", "OFF")
+		// Add additional .define(...) calls if you need to customize the build.
+		.build();
+
+	// In this example, we assume that the built binary ends up under ${dst}/bin/slang.
+	let slang_bin = dst.join("bin").join("slang");
+
+	// Print a message (a Cargo "directive") so that later your Rust code
+	// can retrieve the binary path from the SLANG_PATH environment variable.
+	println!("cargo:rustc-env=SLANG_PATH={}", slang_bin.display());
+
+	// Optionally, print a warning if desired:
+	println!("cargo:warning=Using built Slang binary at: {}", slang_bin.display());
+}

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ fn main() {
 	println!("cargo:rerun-if-changed=build.rs");
 
 	// Define the desired version for Slang.
-	const SLANG_VERSION: &str = "8.0";
+	const SLANG_VERSION: &str = "6.0";
 	// Compute the tarball URL at runtime.
 	let slang_tarball_url = format!(
 		"https://github.com/MikePopoloski/slang/archive/refs/tags/v{}.tar.gz",


### PR DESCRIPTION
Added build.rs to automatically build and install slang via CMake rust package. Does not have to build the slang library beforehand anymore, works automatically with cargo.

i.e. the new build command would be: `cargo build` with no other prerequisite work

Kept the slang version the same as before but seems to have issues with --enable-legacy-protect flag on slang version 6.0 as this seems to be something from version 7.0 of slang. 

I ran with version 7.0 of slang and some tests failed but it seemed to build and run so its a starting point to build off of.