### PR TITLE
Initial feature for hierarchy extraction

### DIFF
--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_json::Value;
+use std::cell::RefCell;
+use std::error::Error;
+use std::rc::Rc;
+
+#[derive(Debug, PartialEq)]
+pub struct Instance {
+    pub def_name: String,
+    pub inst_name: String,
+    pub contents: Vec<Rc<RefCell<Instance>>>,
+}
+
+pub fn extract_hierarchy(cfg: &crate::SlangConfig) -> Result<Instance, Box<dyn Error>> {
+    extract_hierarchy_from_value(&crate::run_slang(cfg)?)
+}
+
+pub fn extract_hierarchy_from_value(value: &Value) -> Result<Instance, Box<dyn Error>> {
+    if let Some(members) = value
+        .get("design")
+        .and_then(|v| v.get("members").and_then(|v| v.as_array()))
+    {
+        for member in members {
+            if let Some((mut inst, value)) = descend_into_instance(member) {
+                extract_hierarchy_from_value_helper(&mut inst, value);
+                return Ok(inst);
+            }
+        }
+    }
+
+    Err("Top-level module not found".into())
+}
+
+fn extract_hierarchy_from_value_helper(top: &mut Instance, value: &Value) {
+    if let Some(members) = value.get("members").and_then(|v| v.as_array()) {
+        for member in members {
+            if let Some((mut inst, value)) = descend_into_instance(member) {
+                extract_hierarchy_from_value_helper(&mut inst, value);
+                top.contents.push(Rc::new(RefCell::new(inst)));
+            }
+        }
+    }
+}
+
+fn descend_into_instance(value: &Value) -> Option<(Instance, &Value)> {
+    if let Some(kind) = value.get("kind") {
+        if kind == "Instance" {
+            if let Some(inst_name) = value.get("name").and_then(|v| v.as_str()) {
+                if inst_name.is_empty() {
+                    return None;
+                }
+                if let Some(body) = value.get("body") {
+                    if let Some(def_name) = body.get("name").and_then(|v| v.as_str()) {
+                        if def_name.is_empty() {
+                            return None;
+                        }
+                        return Some((
+                            Instance {
+                                def_name: def_name.to_string(),
+                                inst_name: inst_name.to_string(),
+                                contents: Vec::new(),
+                            },
+                            body,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ use std::process::Command;
 mod extract;
 pub use extract::{extract_modules, extract_ports, Field, Port, PortDir, Range, Type, Variant};
 
+mod hierarchy;
+pub use hierarchy::{extract_hierarchy, Instance};
+
 #[derive(Debug)]
 pub struct SlangConfig<'a> {
     pub sources: &'a [&'a str],

--- a/tests/hierarchy_test.rs
+++ b/tests/hierarchy_test.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    use slang_rs::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    #[test]
+    fn test_extract_hierarchy() {
+        let verilog = str2tmpfile(
+            "
+            module A;
+              B b0();
+            endmodule
+            module B;
+              C c0();
+              C c1();
+            endmodule
+            module C;
+            endmodule
+            ",
+        )
+        .unwrap();
+
+        let cfg = SlangConfig {
+            sources: &[verilog.path().to_str().unwrap()],
+            ..Default::default()
+        };
+
+        let hierarchy = extract_hierarchy(&cfg);
+
+        let expected = Instance {
+            def_name: "A".to_string(),
+            inst_name: "A".to_string(),
+            contents: vec![Rc::new(RefCell::new(Instance {
+                def_name: "B".to_string(),
+                inst_name: "b0".to_string(),
+                contents: vec![
+                    Rc::new(RefCell::new(Instance {
+                        def_name: "C".to_string(),
+                        inst_name: "c0".to_string(),
+                        contents: vec![],
+                    })),
+                    Rc::new(RefCell::new(Instance {
+                        def_name: "C".to_string(),
+                        inst_name: "c1".to_string(),
+                        contents: vec![],
+                    })),
+                ],
+            }))],
+        };
+
+        assert_eq!(hierarchy.unwrap(), expected);
+    }
+
+    #[test]
+    #[should_panic(expected = "slang command failed")]
+    fn test_extract_hierarchy_error() {
+        let verilog = str2tmpfile(
+            "
+            module A
+            endmodule
+            ",
+        )
+        .unwrap();
+
+        let cfg = SlangConfig {
+            sources: &[verilog.path().to_str().unwrap()],
+            ..Default::default()
+        };
+
+        extract_hierarchy(&cfg).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Top-level module not found")]
+    fn test_top_level_not_found() {
+        let verilog = str2tmpfile("").unwrap();
+
+        let cfg = SlangConfig {
+            sources: &[verilog.path().to_str().unwrap()],
+            ..Default::default()
+        };
+
+        extract_hierarchy(&cfg).unwrap();
+    }
+}


### PR DESCRIPTION
Adds a function `extract_hierarchy`, which returns a tree structure representing the hierarchy of an elaborated design. Each node in the tree is an `Instance` with fields `def_name`, `inst_name`, and `contents` (which holds the instances within a module definition).

To be refined in future PRs - does not yet handle multiple top-level blocks or generate statements.