### PR TITLE
Add support for `generate` constructs in hierarchy extraction

### DIFF
--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -2,6 +2,7 @@
 
 use serde_json::Value;
 use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::rc::Rc;
 
@@ -9,64 +10,176 @@ use std::rc::Rc;
 pub struct Instance {
     pub def_name: String,
     pub inst_name: String,
+    pub hier_prefix: String,
     pub contents: Vec<Rc<RefCell<Instance>>>,
 }
 
-pub fn extract_hierarchy(cfg: &crate::SlangConfig) -> Result<Instance, Box<dyn Error>> {
-    extract_hierarchy_from_value(&crate::run_slang(cfg)?)
+pub fn extract_hierarchy(
+    cfg: &crate::SlangConfig,
+) -> Result<HashMap<String, Instance>, Box<dyn Error>> {
+    Ok(extract_hierarchy_from_value(&crate::run_slang(cfg)?))
 }
 
-pub fn extract_hierarchy_from_value(value: &Value) -> Result<Instance, Box<dyn Error>> {
+pub fn extract_hierarchy_from_value(value: &Value) -> HashMap<String, Instance> {
+    let mut top_level_instances = HashMap::new();
+
     if let Some(members) = value
         .get("design")
         .and_then(|v| v.get("members").and_then(|v| v.as_array()))
     {
         for member in members {
-            if let Some((mut inst, value)) = descend_into_instance(member) {
-                extract_hierarchy_from_value_helper(&mut inst, value);
-                return Ok(inst);
-            }
-        }
-    }
-
-    Err("Top-level module not found".into())
-}
-
-fn extract_hierarchy_from_value_helper(top: &mut Instance, value: &Value) {
-    if let Some(members) = value.get("members").and_then(|v| v.as_array()) {
-        for member in members {
-            if let Some((mut inst, value)) = descend_into_instance(member) {
-                extract_hierarchy_from_value_helper(&mut inst, value);
-                top.contents.push(Rc::new(RefCell::new(inst)));
-            }
-        }
-    }
-}
-
-fn descend_into_instance(value: &Value) -> Option<(Instance, &Value)> {
-    if let Some(kind) = value.get("kind") {
-        if kind == "Instance" {
-            if let Some(inst_name) = value.get("name").and_then(|v| v.as_str()) {
-                if inst_name.is_empty() {
-                    return None;
-                }
-                if let Some(body) = value.get("body") {
-                    if let Some(def_name) = body.get("name").and_then(|v| v.as_str()) {
-                        if def_name.is_empty() {
-                            return None;
-                        }
-                        return Some((
-                            Instance {
-                                def_name: def_name.to_string(),
-                                inst_name: inst_name.to_string(),
-                                contents: Vec::new(),
-                            },
-                            body,
-                        ));
+            if let Some(kind) = member.get("kind") {
+                if kind == "Instance" {
+                    if let Some((mut inst, value)) = descend_into_instance(member, "".to_string()) {
+                        extract_hierarchy_from_value_helper(&mut inst, value, "".to_string());
+                        top_level_instances.insert(inst.def_name.clone(), inst);
                     }
                 }
             }
         }
     }
+
+    top_level_instances
+}
+
+fn extract_hierarchy_from_value_helper(top: &mut Instance, value: &Value, hier_prefix: String) {
+    let symbol_table = create_symbol_table(value);
+    if let Some(members) = value.get("members").and_then(|v| v.as_array()) {
+        for member in members {
+            if let Some(kind) = member.get("kind") {
+                if kind == "Instance" {
+                    if let Some((mut inst, value)) =
+                        descend_into_instance(member, hier_prefix.clone())
+                    {
+                        extract_hierarchy_from_value_helper(&mut inst, value, "".to_string());
+                        top.contents.push(Rc::new(RefCell::new(inst)));
+                    }
+                } else if kind == "GenerateBlock" {
+                    if let Some((hier_prefix, value)) =
+                        descend_into_generate_block(member, hier_prefix.clone(), &symbol_table)
+                    {
+                        extract_hierarchy_from_value_helper(top, value, hier_prefix.clone());
+                    }
+                } else if kind == "GenerateBlockArray" {
+                    if let Some(elements) = descend_into_generate_block_array(
+                        member,
+                        hier_prefix.clone(),
+                        &symbol_table,
+                    ) {
+                        for (hier_prefix, element) in elements {
+                            extract_hierarchy_from_value_helper(top, element, hier_prefix.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn descend_into_instance(value: &Value, hier_prefix: String) -> Option<(Instance, &Value)> {
+    if let Some(inst_name) = value.get("name").and_then(|v| v.as_str()) {
+        if inst_name.is_empty() {
+            return None;
+        }
+        if let Some(body) = value.get("body") {
+            if let Some(def_name) = body.get("name").and_then(|v| v.as_str()) {
+                if def_name.is_empty() {
+                    return None;
+                }
+                return Some((
+                    Instance {
+                        def_name: def_name.to_string(),
+                        inst_name: inst_name.to_string(),
+                        hier_prefix,
+                        contents: Vec::new(),
+                    },
+                    body,
+                ));
+            }
+        }
+    }
+
     None
+}
+
+fn descend_into_generate_block<'a>(
+    value: &'a Value,
+    hier_prefix: String,
+    symbol_table: &HashSet<String>,
+) -> Option<(String, &'a Value)> {
+    if let Some(name) = value.get("name").and_then(|v| v.as_str()) {
+        if let Some(index) = value.get("constructIndex").and_then(|v| v.as_i64()) {
+            if let Some(uninstantiated) = value.get("isUninstantiated").and_then(|v| v.as_bool()) {
+                if uninstantiated {
+                    return None;
+                }
+                let genblk_name = if name.is_empty() {
+                    get_default_genblk_name(index as usize, symbol_table)
+                } else {
+                    name.to_string()
+                };
+                let hier_prefix = format!("{hier_prefix}.{genblk_name}");
+                return Some((hier_prefix, value));
+            }
+        }
+    }
+
+    None
+}
+
+fn descend_into_generate_block_array<'a>(
+    value: &'a Value,
+    hier_prefix: String,
+    symbol_table: &HashSet<String>,
+) -> Option<Vec<(String, &'a Value)>> {
+    if let Some(name) = value.get("name").and_then(|v| v.as_str()) {
+        if let Some(index) = value.get("constructIndex").and_then(|v| v.as_i64()) {
+            if let Some(members) = value.get("members").and_then(|v| v.as_array()) {
+                let genblk_name = if name.is_empty() {
+                    get_default_genblk_name(index as usize, symbol_table)
+                } else {
+                    name.to_string()
+                };
+                let hier_prefix = format!("{hier_prefix}.{genblk_name}");
+
+                let mut elements = Vec::new();
+                for member in members {
+                    if let Some(kind) = member.get("kind") {
+                        if kind == "GenerateBlock" {
+                            if let Some(subidx) =
+                                member.get("constructIndex").and_then(|v| v.as_i64())
+                            {
+                                elements.push((format!("{hier_prefix}[{subidx}]"), member));
+                            }
+                        }
+                    }
+                }
+                return Some(elements);
+            }
+        }
+    }
+
+    None
+}
+
+fn create_symbol_table(value: &Value) -> HashSet<String> {
+    let mut table = HashSet::new();
+    if let Some(members) = value.get("members").and_then(|v| v.as_array()) {
+        for member in members {
+            if let Some(name) = member.get("name") {
+                if !name.as_str().unwrap().is_empty() {
+                    table.insert(name.as_str().unwrap().to_string());
+                }
+            }
+        }
+    }
+    table
+}
+
+fn get_default_genblk_name(index: usize, symbol_table: &HashSet<String>) -> String {
+    let mut prefix = "genblk".to_string();
+    while symbol_table.contains(&format!("{prefix}{index}")) {
+        prefix = format!("{prefix}0");
+    }
+    format!("{prefix}{index}")
 }

--- a/tests/hierarchy_test.rs
+++ b/tests/hierarchy_test.rs
@@ -4,6 +4,7 @@
 mod tests {
     use slang_rs::*;
     use std::cell::RefCell;
+    use std::collections::HashMap;
     use std::rc::Rc;
 
     #[test]
@@ -33,23 +34,127 @@ mod tests {
         let expected = Instance {
             def_name: "A".to_string(),
             inst_name: "A".to_string(),
+            hier_prefix: "".to_string(),
             contents: vec![Rc::new(RefCell::new(Instance {
                 def_name: "B".to_string(),
                 inst_name: "b0".to_string(),
+                hier_prefix: "".to_string(),
                 contents: vec![
                     Rc::new(RefCell::new(Instance {
                         def_name: "C".to_string(),
                         inst_name: "c0".to_string(),
+                        hier_prefix: "".to_string(),
                         contents: vec![],
                     })),
                     Rc::new(RefCell::new(Instance {
                         def_name: "C".to_string(),
                         inst_name: "c1".to_string(),
+                        hier_prefix: "".to_string(),
                         contents: vec![],
                     })),
                 ],
             }))],
         };
+
+        let expected = HashMap::from([("A".to_string(), expected)]);
+
+        assert_eq!(hierarchy.unwrap(), expected);
+    }
+
+    #[test]
+    fn test_extract_hierarchy_genblk() {
+        // Test verilog adapted from tests/unittests/ast/HierarchyTests.cpp
+        // in https://github.com/MikePopoloski/slang
+
+        let verilog = str2tmpfile(
+            "
+module A;
+endmodule
+module B;
+endmodule
+module top;
+    parameter genblk2 = 0;
+    genvar i;
+
+    // The following generate block is implicitly named genblk1
+    if (genblk2) A a(); // top.genblk1.a
+    else B b(); // top.genblk1.b
+
+    // The following generate block is implicitly named genblk02
+    // as genblk2 is already a declared identifier
+    if (genblk2) A a(); // top.genblk02.a
+    else B b(); // top.genblk02.b
+
+    // The following generate block would have been named genblk3
+    // but is explicitly named g1
+    for (i = 0; i < 1; i = i + 1) begin : g1 // block name
+        // The following generate block is implicitly named genblk1
+        // as the first nested scope inside g1
+        if (1) A a(); // top.g1[0].genblk1.a
+    end
+
+    // The following generate block is implicitly named genblk4 since
+    // it belongs to the fourth generate construct in scope 'top'.
+    // The previous generate block would have been
+    // named genblk3 if it had not been explicitly named g1
+    for (i = 0; i < 1; i = i + 1)
+        // The following generate block is implicitly named genblk1
+        // as the first nested generate block in genblk4
+        if (1) A a(); // top.genblk4[0].genblk1.a
+
+    // The following generate block is implicitly named genblk5
+    if (1) A a(); // top.genblk5.a
+endmodule
+            ",
+        )
+        .unwrap();
+
+        let cfg = SlangConfig {
+            sources: &[verilog.path().to_str().unwrap()],
+            ..Default::default()
+        };
+
+        let hierarchy = extract_hierarchy(&cfg);
+
+        let expected = Instance {
+            def_name: "top".to_string(),
+            inst_name: "top".to_string(),
+            hier_prefix: "".to_string(),
+            contents: vec![
+                Rc::new(RefCell::new(Instance {
+                    def_name: "B".to_string(),
+                    inst_name: "b".to_string(),
+                    hier_prefix: ".genblk1".to_string(),
+                    contents: vec![],
+                })),
+                Rc::new(RefCell::new(Instance {
+                    def_name: "B".to_string(),
+                    inst_name: "b".to_string(),
+                    hier_prefix: ".genblk02".to_string(),
+                    contents: vec![],
+                })),
+                Rc::new(RefCell::new(Instance {
+                    def_name: "A".to_string(),
+                    inst_name: "a".to_string(),
+                    hier_prefix: ".g1[0].genblk1".to_string(),
+                    contents: vec![],
+                })),
+                Rc::new(RefCell::new(Instance {
+                    def_name: "A".to_string(),
+                    inst_name: "a".to_string(),
+                    hier_prefix: ".genblk4[0].genblk1".to_string(),
+                    contents: vec![],
+                })),
+                Rc::new(RefCell::new(Instance {
+                    def_name: "A".to_string(),
+                    inst_name: "a".to_string(),
+                    hier_prefix: ".genblk5".to_string(),
+                    contents: vec![],
+                })),
+            ],
+        };
+
+        let expected = HashMap::from([("top".to_string(), expected)]);
 
         assert_eq!(hierarchy.unwrap(), expected);
     }
@@ -64,19 +169,6 @@ mod tests {
             ",
         )
         .unwrap();
-
-        let cfg = SlangConfig {
-            sources: &[verilog.path().to_str().unwrap()],
-            ..Default::default()
-        };
-
-        extract_hierarchy(&cfg).unwrap();
-    }
-
-    #[test]
-    #[should_panic(expected = "Top-level module not found")]
-    fn test_top_level_not_found() {
-        let verilog = str2tmpfile("").unwrap();
 
         let cfg = SlangConfig {
             sources: &[verilog.path().to_str().unwrap()],


### PR DESCRIPTION
Each `Instance` returned by `extract_hierarchy` contains a new field, `hier_prefix`, that should be prepended to the instance name when forming full hierarchical paths. `hier_prefix` represents additional layers of hierarchy that are added by `generate` constructs. Both `if` statements and `for` loops are supported.

Also in this PR, `extract_hierarchy` now works more like `extract_ports` in that it returns a `HashMap` mapping the name of a top-level module definition to the corresponding `Instance`. Before, the only the first top-level module was returned.