### PR TITLE
Initial parameter support + `_from_value` variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,7 +569,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slang-rs"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slang-rs"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust bindings for the Slang Verilog parser"

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -6,8 +6,7 @@ use std::error::Error;
 use std::str::FromStr;
 
 mod type_extract;
-use type_extract::parse_type_definition;
-pub use type_extract::{Field, Range, Type, Variant};
+pub use type_extract::{parse_type_definition, Field, Range, Type, Variant};
 
 #[derive(Debug, PartialEq)]
 pub enum PortDir {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,16 @@ use std::fs::{self, write};
 use std::process::Command;
 
 mod extract;
-pub use extract::{extract_modules, extract_ports, Field, Port, PortDir, Range, Type, Variant};
+pub use extract::{
+    extract_modules, extract_modules_from_value, extract_ports, extract_ports_from_value, Field,
+    Port, PortDir, Range, Type, Variant,
+};
 
 mod hierarchy;
-pub use hierarchy::{extract_hierarchy, Instance};
+pub use hierarchy::{extract_hierarchy, extract_hierarchy_from_value, Instance};
+
+mod package;
+pub use package::{extract_packages, extract_packages_from_value, Package, Parameter};
 
 #[derive(Debug)]
 pub struct SlangConfig<'a> {

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_json::Value;
+use std::collections::HashMap;
+use std::error::Error;
+use std::ops::Index;
+use std::str::FromStr;
+
+#[derive(Debug, PartialEq)]
+
+pub struct Parameter {
+    pub name: String,
+    pub value: String,
+}
+
+impl Parameter {
+    /// Parse the parameter's `value` into any type that implements [`FromStr`].
+    ///
+    /// # Type Parameters
+    ///
+    /// * **`T`** – The numeric type you want (`i64`, `u128`,
+    ///   [`num_bigint::BigInt`], [`num_bigint::BigUint`], `f64`, ...).
+    ///   `T` only needs to satisfy `T: FromStr`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(T::Err)` if `value` is *not* a valid textual
+    /// representation for `T`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use num_bigint::{BigInt, BigUint};
+    /// use std::convert::TryFrom;
+    ///
+    /// # use slang_rs::Parameter;
+    /// let p = Parameter { name: "answer".into(), value: "42".into() };
+    ///
+    /// // Primitive integer (type inferred)
+    /// let n: i32 = p.parse().unwrap();
+    ///
+    /// // Explicit turbofish when inference can’t decide
+    /// let n128 = p.parse::<u128>().unwrap();
+    ///
+    /// // Big integers
+    /// let big:  BigInt  = p.parse().unwrap();
+    /// let ubig: BigUint = p.parse().unwrap();
+    /// ```
+    pub fn parse<T>(&self) -> Result<T, T::Err>
+    where
+        T: FromStr,
+    {
+        self.value.parse()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Package {
+    pub name: String,
+    pub parameters: HashMap<String, Parameter>,
+}
+
+impl Index<&str> for Package {
+    type Output = Parameter;
+
+    fn index(&self, key: &str) -> &Self::Output {
+        &self.parameters[key]
+    }
+}
+
+pub fn extract_packages(
+    cfg: &crate::SlangConfig,
+) -> Result<HashMap<String, Package>, Box<dyn Error>> {
+    Ok(extract_packages_from_value(&crate::run_slang(cfg)?))
+}
+
+pub fn extract_packages_from_value(value: &Value) -> HashMap<String, Package> {
+    let mut packages = HashMap::new();
+
+    if let Some(members) = value
+        .get("design")
+        .and_then(|v| v.get("members").and_then(|v| v.as_array()))
+    {
+        for member in members {
+            if let Some(kind) = member.get("kind") {
+                if kind == "CompilationUnit" {
+                    extract_packages_from_compilation_unit(member, &mut packages);
+                }
+            }
+        }
+    }
+
+    packages
+}
+
+fn extract_packages_from_compilation_unit(value: &Value, packages: &mut HashMap<String, Package>) {
+    if let Some(members) = value.get("members").and_then(|v| v.as_array()) {
+        for member in members {
+            if let Some(kind) = member.get("kind") {
+                if kind == "Package" {
+                    if let Some(name) = member.get("name").and_then(|v| v.as_str()) {
+                        let mut package = Package {
+                            name: name.to_string(),
+                            parameters: HashMap::new(),
+                        };
+                        if let Some(members) = member.get("members").and_then(|v| v.as_array()) {
+                            for member in members {
+                                if let Some(kind) = member.get("kind") {
+                                    if kind == "Parameter" {
+                                        if let Some(parameter) = process_parameter(member) {
+                                            package
+                                                .parameters
+                                                .insert(parameter.name.clone(), parameter);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        packages.insert(name.to_string(), package);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn process_parameter(member: &Value) -> Option<Parameter> {
+    if let Some(value) = member.get("value").and_then(|v| v.as_str()) {
+        if let Some(name) = member.get("name").and_then(|v| v.as_str()) {
+            return Some(Parameter {
+                name: name.to_string(),
+                value: value.to_string(),
+            });
+        }
+    }
+    None
+}

--- a/tests/all_test.rs
+++ b/tests/all_test.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    use slang_rs::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::rc::Rc;
+
+    #[test]
+    fn test_extract_all() {
+        let verilog = str2tmpfile(
+            "
+            module B;
+            endmodule
+            module A(
+              input x,
+              output y
+            );
+              B b();
+            endmodule
+            package mypkg;
+              localparam int myparam=42;
+            endpackage
+            ",
+        )
+        .unwrap();
+
+        let cfg = SlangConfig {
+            sources: &[verilog.path().to_str().unwrap()],
+            ..Default::default()
+        };
+
+        let value = run_slang(&cfg).unwrap();
+
+        // check ports
+
+        let ports = extract_ports_from_value(&value, false);
+
+        let expected_ports = HashMap::from([(
+            "A".to_string(),
+            vec![
+                Port {
+                    name: "x".to_string(),
+                    dir: PortDir::Input,
+                    ty: Type::Logic {
+                        signed: false,
+                        packed_dimensions: vec![],
+                        unpacked_dimensions: vec![],
+                    },
+                },
+                Port {
+                    name: "y".to_string(),
+                    dir: PortDir::Output,
+                    ty: Type::Logic {
+                        signed: false,
+                        packed_dimensions: vec![],
+                        unpacked_dimensions: vec![],
+                    },
+                },
+            ],
+        )]);
+
+        assert_eq!(ports, expected_ports);
+
+        // check hierarchy
+
+        let hierarchy = extract_hierarchy_from_value(&value);
+
+        let expected_hierarchy = HashMap::from([(
+            "A".to_string(),
+            Instance {
+                def_name: "A".to_string(),
+                inst_name: "A".to_string(),
+                hier_prefix: "".to_string(),
+                contents: vec![Rc::new(RefCell::new(Instance {
+                    def_name: "B".to_string(),
+                    inst_name: "b".to_string(),
+                    hier_prefix: "".to_string(),
+                    contents: vec![],
+                }))],
+            },
+        )]);
+
+        assert_eq!(hierarchy, expected_hierarchy);
+
+        // check packages
+
+        let packages = extract_packages_from_value(&value);
+
+        let expected_packages = HashMap::from([(
+            "mypkg".to_string(),
+            Package {
+                name: "mypkg".to_string(),
+                parameters: HashMap::from([(
+                    "myparam".to_string(),
+                    Parameter {
+                        name: "myparam".to_string(),
+                        value: "42".to_string(),
+                    },
+                )]),
+            },
+        )]);
+
+        assert_eq!(packages, expected_packages);
+    }
+}

--- a/tests/package_test.rs
+++ b/tests/package_test.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    use num_bigint::BigInt;
+    use slang_rs::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_extract_packages() {
+        let verilog = str2tmpfile(
+            "
+            package pkg_a;
+              localparam int a=22;
+            endpackage
+            package pkg_b;
+              localparam int b=123;
+              localparam int c=b+pkg_a::a;
+              typedef logic [33:22] my_t;
+            endpackage
+            ",
+        )
+        .unwrap();
+
+        let cfg = SlangConfig {
+            sources: &[verilog.path().to_str().unwrap()],
+            ..Default::default()
+        };
+
+        let pkgs = extract_packages(&cfg).unwrap();
+
+        let expected = HashMap::from([
+            (
+                "pkg_a".to_string(),
+                Package {
+                    name: "pkg_a".to_string(),
+                    parameters: HashMap::from([(
+                        "a".to_string(),
+                        Parameter {
+                            name: "a".to_string(),
+                            value: "22".to_string(),
+                        },
+                    )]),
+                },
+            ),
+            (
+                "pkg_b".to_string(),
+                Package {
+                    name: "pkg_b".to_string(),
+                    parameters: HashMap::from([
+                        (
+                            "b".to_string(),
+                            Parameter {
+                                name: "b".to_string(),
+                                value: "123".to_string(),
+                            },
+                        ),
+                        (
+                            "c".to_string(),
+                            Parameter {
+                                name: "c".to_string(),
+                                value: "145".to_string(),
+                            },
+                        ),
+                    ]),
+                },
+            ),
+        ]);
+
+        assert_eq!(pkgs, expected);
+
+        assert_eq!(
+            pkgs["pkg_a"]["a"].parse::<BigInt>().unwrap(),
+            BigInt::from(22)
+        );
+        assert_eq!(pkgs["pkg_b"]["b"].parse::<i32>().unwrap(), 123);
+        assert_eq!(pkgs["pkg_b"]["c"].parse::<u64>().unwrap(), 145u64);
+    }
+
+    #[test]
+    #[should_panic(expected = "slang command failed")]
+    fn test_extract_packages_error() {
+        let verilog = str2tmpfile(
+            "
+            package A
+            endpackage
+            ",
+        )
+        .unwrap();
+
+        let cfg = SlangConfig {
+            sources: &[verilog.path().to_str().unwrap()],
+            ..Default::default()
+        };
+
+        extract_packages(&cfg).unwrap();
+    }
+}


### PR DESCRIPTION
Initial support for parameters involves returning a package name -> `Package` struct map. Each `Package` struct can be accessed as a map of parameter name -> `Parameter` struct. `Parameter` structs store values as strings but provide a generic `parse` method that can be used to convert to standard numeric types, bigints, etc. In the future this may be made more robust by taking into account the `Type` of parameters, reusing infrastructure already in place for working with ports.

The other change in this PR is to add `_from_value` variants for port, hierarchy, and package parsing. This avoids the need to parse Verilog sources multiple times to extract multiple types of information.