### PR TITLE
Mechanism for passing in extra arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,7 +569,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slang-rs"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slang-rs"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust bindings for the Slang Verilog parser"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub struct SlangConfig<'a> {
     pub ignore_unknown_modules: bool,
     pub ignore_protected: bool,
     pub timescale: Option<&'a str>,
+    pub extra_arguments: &'a [&'a str],
 }
 
 impl<'a> Default for SlangConfig<'a> {
@@ -46,6 +47,7 @@ impl<'a> Default for SlangConfig<'a> {
             ignore_unknown_modules: true,
             ignore_protected: true,
             timescale: None,
+            extra_arguments: &[],
         }
     }
 }
@@ -109,6 +111,10 @@ pub fn run_slang(cfg: &SlangConfig) -> Result<Value, Box<dyn std::error::Error>>
 
     if cfg.ignore_protected {
         push_options_to_ignore_protected(&mut args);
+    }
+
+    for extra_arg in cfg.extra_arguments.iter() {
+        args.push(extra_arg);
     }
 
     let param_args: Vec<String> = cfg

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -805,4 +805,38 @@ endmodule
 
         assert_eq!(definitions["foo"][0].ty.width().unwrap(), 2);
     }
+
+    #[test]
+    fn test_enum_conversion() {
+        let verilog = str2tmpfile(
+            "
+        typedef enum logic [1:0] {
+            A=0,
+            B=1,
+            C=2
+        } enum_t;
+
+        module foo (
+            output enum_t a,
+            input logic [1:0] b
+        );
+            assign a = b;
+        endmodule",
+        )
+        .unwrap();
+
+        let cfg = SlangConfig {
+            sources: &[verilog.path().to_str().unwrap()],
+            extra_arguments: &["--relax-enum-conversions"],
+            ..Default::default()
+        };
+
+        let ports = extract_ports(&cfg, false);
+
+        assert_eq!(ports["foo"].len(), 2);
+        assert_eq!(ports["foo"][0].name, "a");
+        assert_eq!(ports["foo"][0].ty.width().unwrap(), 2);
+        assert_eq!(ports["foo"][1].name, "b");
+        assert_eq!(ports["foo"][1].ty.width().unwrap(), 2);
+    }
 }


### PR DESCRIPTION
Extra arguments can now be passed to slang via `SlangConfig.extra_arguments`. Generally useful arguments should be folded back into `slang-rs` defaults, but this feature provides a quick mechanism for experimentation.