### PR TITLE
Extract typedefs from packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,7 +569,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slang-rs"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slang-rs"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust bindings for the Slang Verilog parser"

--- a/src/extract/grammar.pest
+++ b/src/extract/grammar.pest
@@ -4,7 +4,7 @@ WHITESPACE = _{ " " | "\t" | "\n" | "\r" }
 
 identifier = @{ (ASCII_ALPHANUMERIC | "_")+ }
 
-full_identifier = @{ (ASCII_ALPHANUMERIC | "_" | ":")+ }
+full_identifier = @{ (ASCII_ALPHANUMERIC | "_" | ":" | "$")+ }
 
 negative_sign = { "-" }
 

--- a/src/extract/type_extract.rs
+++ b/src/extract/type_extract.rs
@@ -142,6 +142,7 @@ impl Type {
     }
 }
 
+/// Parses a slang type definition (from --ast-json) into a `Type`
 pub fn parse_type_definition(input: &str) -> Result<Type, Box<dyn Error>> {
     let mut parse_tree = DataTypeParser::parse(Rule::top, input)?;
     let ty = parse_tree.next().unwrap().into_inner().next().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@ use std::process::Command;
 
 mod extract;
 pub use extract::{
-    extract_modules, extract_modules_from_value, extract_ports, extract_ports_from_value, Field,
-    Port, PortDir, Range, Type, Variant,
+    extract_modules, extract_modules_from_value, extract_ports, extract_ports_from_value,
+    parse_type_definition, Field, Port, PortDir, Range, Type, Variant,
 };
 
 mod hierarchy;

--- a/src/package.rs
+++ b/src/package.rs
@@ -112,6 +112,12 @@ fn extract_packages_from_compilation_unit(value: &Value, packages: &mut HashMap<
                                                 .parameters
                                                 .insert(parameter.name.clone(), parameter);
                                         }
+                                    } else if kind == "TypeAlias" {
+                                        if let Some(type_alias) = process_type_alias(member) {
+                                            package
+                                                .parameters
+                                                .insert(type_alias.name.clone(), type_alias);
+                                        }
                                     }
                                 }
                             }
@@ -130,6 +136,18 @@ fn process_parameter(member: &Value) -> Option<Parameter> {
             return Some(Parameter {
                 name: name.to_string(),
                 value: value.to_string(),
+            });
+        }
+    }
+    None
+}
+
+fn process_type_alias(member: &Value) -> Option<Parameter> {
+    if let Some(target) = member.get("target").and_then(|v| v.as_str()) {
+        if let Some(name) = member.get("name").and_then(|v| v.as_str()) {
+            return Some(Parameter {
+                name: name.to_string(),
+                value: target.to_string(),
             });
         }
     }


### PR DESCRIPTION
Expands on existing functionality to parse packages, reporting typedefs in addition to parameters. Like parameters, typedefs are reported as strings, but can be parsed to a `Type` with `parse_type_definition`. This function already existed in `slang-rs`, but is made public as part of this PR.