### PR TITLE
[slang] Update to 11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,10 @@ jobs:
 
       - name: Download Slang
         run: |
-          curl --fail --location --proto '=https' --tlsv1.2 -o slang \
-            "https://github.com/xlsynth/slang-rs/releases/download/ci/slang"
-          echo "0ae872c4d877eb153b21a9f2c78409a27a8e8a46ec956176e8b5f4c1c09874ea  slang" | sha256sum -c -
+          curl --fail --location --proto '=https' --tlsv1.2 -o "$RUNNER_TEMP/slang.tar.gz" \
+            "https://github.com/MikePopoloski/slang/releases/download/v11.0/slang-linux-x86_64.tar.gz"
+          echo "951a170e10e25e54c91565030acfdfc11c3226714ebf225a18ad4166a898d8a4  $RUNNER_TEMP/slang.tar.gz" | sha256sum -c -
+          tar -xzf "$RUNNER_TEMP/slang.tar.gz"
           chmod +x slang
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,8 @@ jobs:
           curl --fail --location --proto '=https' --tlsv1.2 -o "$RUNNER_TEMP/slang.tar.gz" \
             "https://github.com/MikePopoloski/slang/releases/download/v11.0/slang-linux-x86_64.tar.gz"
           echo "951a170e10e25e54c91565030acfdfc11c3226714ebf225a18ad4166a898d8a4  $RUNNER_TEMP/slang.tar.gz" | sha256sum -c -
-          tar -xzf "$RUNNER_TEMP/slang.tar.gz"
-          chmod +x slang
+          tar -xzf "$RUNNER_TEMP/slang.tar.gz" -C "$RUNNER_TEMP"
+          chmod +x "$RUNNER_TEMP/slang"
 
       - name: Run tests
-        run: export SLANG_PATH=`realpath slang` && cargo test --locked
+        run: SLANG_PATH="$RUNNER_TEMP/slang" cargo test --locked

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,9 +49,10 @@ jobs:
 
     - name: Build and test
       run: |
-        curl --fail --location --proto '=https' --tlsv1.2 -o "$RUNNER_TEMP/slang" \
-          "https://github.com/xlsynth/slang-rs/releases/download/ci/slang"
-        echo "0ae872c4d877eb153b21a9f2c78409a27a8e8a46ec956176e8b5f4c1c09874ea  $RUNNER_TEMP/slang" | sha256sum -c -
+        curl --fail --location --proto '=https' --tlsv1.2 -o "$RUNNER_TEMP/slang.tar.gz" \
+          "https://github.com/MikePopoloski/slang/releases/download/v11.0/slang-linux-x86_64.tar.gz"
+        echo "951a170e10e25e54c91565030acfdfc11c3226714ebf225a18ad4166a898d8a4  $RUNNER_TEMP/slang.tar.gz" | sha256sum -c -
+        tar -xzf "$RUNNER_TEMP/slang.tar.gz" -C "$RUNNER_TEMP"
         chmod +x "$RUNNER_TEMP/slang"
         export SLANG_PATH="$RUNNER_TEMP/slang"
         cargo test --locked

--- a/.github/workflows/slang.yml
+++ b/.github/workflows/slang.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Download Slang Release
         run: |
           curl --fail --location --proto '=https' --tlsv1.2 -o source.tar.gz \
-            "https://github.com/MikePopoloski/slang/archive/refs/tags/v7.0.tar.gz"
-          echo "5faa9bdac043b81eb489f0dd0de36443f6d5868460b7b442df87a6e8210e8547  source.tar.gz" | sha256sum -c -
+            "https://github.com/MikePopoloski/slang/archive/refs/tags/v11.0.tar.gz"
+          echo "50676d5a9adbefb97d266a4b174e6b0513901afd5ac57a6cdfea0a61149c3704  source.tar.gz" | sha256sum -c -
 
       - name: Extract Tarball
         run: |
@@ -58,8 +58,8 @@ jobs:
       - name: Download Slang Release
         run: |
           curl --fail --location --proto '=https' --tlsv1.2 -o source.tar.gz \
-            "https://github.com/MikePopoloski/slang/archive/refs/tags/v7.0.tar.gz"
-          echo "5faa9bdac043b81eb489f0dd0de36443f6d5868460b7b442df87a6e8210e8547  source.tar.gz" | sha256sum -c -
+            "https://github.com/MikePopoloski/slang/archive/refs/tags/v11.0.tar.gz"
+          echo "50676d5a9adbefb97d266a4b174e6b0513901afd5ac57a6cdfea0a61149c3704  source.tar.gz" | sha256sum -c -
 
       - name: Extract Tarball
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,7 +569,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slang-rs"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "cargo_metadata",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slang-rs"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Rust bindings for the Slang Verilog parser"

--- a/README.md
+++ b/README.md
@@ -4,19 +4,29 @@ Parse SystemVerilog with Slang using a Rust API.
 
 Note: the API is currently under development and is subject to frequent changes.
 
+## Slang version compatibility
+
+Slang 11.0 is the currently supported release and the version used by this
+project's CI and installation instructions.
+
+Older Slang releases may continue to work, but are considered deprecated and
+are not guaranteed to remain compatible in future `slang-rs` releases. Slang
+7.0 has been tested with the current compatibility layer; other older versions
+have not been validated.
+
 ## Prerequisite
 
 First install the Slang parser. We recommend building it from source.
 
 ```shell
-curl --fail --location --proto '=https' --tlsv1.2 -o v6.0.tar.gz \
-  "https://github.com/MikePopoloski/slang/archive/refs/tags/v6.0.tar.gz"
-echo "c4c43f4ef7e2dcaca15541442f9e75ce8749eb0a16224b7c1a6a3c42ae468179  v6.0.tar.gz" | sha256sum -c -
-tar xzvf v6.0.tar.gz
+curl --fail --location --proto '=https' --tlsv1.2 -o v11.0.tar.gz \
+  "https://github.com/MikePopoloski/slang/archive/refs/tags/v11.0.tar.gz"
+echo "50676d5a9adbefb97d266a4b174e6b0513901afd5ac57a6cdfea0a61149c3704  v11.0.tar.gz" | sha256sum -c -
+tar xzvf v11.0.tar.gz
 ```
 
 ```shell
-cd slang-6.0
+cd slang-11.0
 ```
 
 ```shell

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,5 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
+//! Extraction and compatibility support for Slang's serialized AST.
+//!
+//! Slang releases before v10 generally printed a complete textual type at each
+//! use site in `--ast-json`. For example, a port declared with a packed struct
+//! typedef could have a `type` field like:
+//!
+//! ```text
+//! struct packed{logic[7:0] data;}bus_t
+//! ```
+//!
+//! Starting in Slang v10, the serializer avoids repeating types that it has
+//! already emitted. Later uses are encoded as an address followed by the type's
+//! display name, for example `6338692580072 bus_t`. The address identifies an
+//! object elsewhere in the same JSON document via that object's `addr` field.
+//! Links can also occur inside other textual type definitions, so typedefs may
+//! form a chain of references.
+//!
+//! The parser in [`type_extract`] consumes the older, self-contained textual
+//! representation. [`TypeResolver`] bridges the formats by indexing addressable
+//! JSON nodes and expanding v10+ links back into that representation before
+//! parsing. Older inline types contain no links and pass through unchanged.
+
+use num_bigint::BigInt;
+use num_traits::Num;
+use regex::Regex;
 use serde_json::Value;
 use std::collections::{HashMap, hash_map::Entry};
 use std::error::Error;
@@ -111,6 +136,7 @@ pub fn extract_ports_from_value(
     skip_unsupported: bool,
 ) -> HashMap<String, Vec<Port>> {
     let mut ports_map = HashMap::new();
+    let type_resolver = TypeResolver::new(value);
 
     for member in MemberIter::new(&value["design"], &["Instance"]) {
         let module_name = member["name"].as_str().unwrap();
@@ -118,14 +144,15 @@ pub fn extract_ports_from_value(
             continue;
         }
         let mut ports = Vec::new();
-        for instance_member in MemberIter::new(&member["body"], &["Port", "InterfacePort"]) {
+        let body = type_resolver.resolve_node(&member["body"]);
+        for instance_member in MemberIter::new(body, &["Port", "InterfacePort"]) {
             let kind = instance_member["kind"].as_str().unwrap();
             match kind {
                 "Port" => {
                     let port_name = instance_member["name"].as_str().unwrap();
                     let direction = instance_member["direction"].as_str().unwrap();
-                    let type_str = instance_member["type"].as_str().unwrap();
-                    match parse_type_definition_no_error(type_str) {
+                    let type_str = type_resolver.resolve(instance_member["type"].as_str().unwrap());
+                    match parse_type_definition_no_error(&type_str) {
                         Ok(ty) => ports.push(Port {
                             dir: PortDir::from_str(direction).unwrap(),
                             name: port_name.to_string(),
@@ -149,7 +176,7 @@ pub fn extract_ports_from_value(
             }
         }
         insert_to_vacant(&mut ports_map, module_name.to_string(), ports)
-            .expect(format!("Duplicate definition of module: {}", module_name).as_str());
+            .unwrap_or_else(|_| panic!("Duplicate definition of module: {module_name}"));
     }
 
     ports_map
@@ -160,6 +187,7 @@ pub fn extract_parameter_defs_from_value(
     skip_unsupported: bool,
 ) -> HashMap<String, Vec<ParameterDef>> {
     let mut parameters_map = HashMap::new();
+    let type_resolver = TypeResolver::new(value);
 
     for member in MemberIter::new(&value["design"], &["Instance"]) {
         let module_name = member["name"].as_str().unwrap();
@@ -167,10 +195,11 @@ pub fn extract_parameter_defs_from_value(
             continue;
         }
         let mut parameters = Vec::new();
-        for instance_member in MemberIter::new(&member["body"], &["Parameter"]) {
+        let body = type_resolver.resolve_node(&member["body"]);
+        for instance_member in MemberIter::new(body, &["Parameter"]) {
             let parameter_name = instance_member["name"].as_str().unwrap();
-            let type_str = instance_member["type"].as_str().unwrap();
-            match parse_type_definition_no_error(type_str) {
+            let type_str = type_resolver.resolve(instance_member["type"].as_str().unwrap());
+            match parse_type_definition_no_error(&type_str) {
                 Ok(ty) => parameters.push(ParameterDef {
                     name: parameter_name.to_string(),
                     ty,
@@ -185,7 +214,7 @@ pub fn extract_parameter_defs_from_value(
             }
         }
         insert_to_vacant(&mut parameters_map, module_name.to_string(), parameters)
-            .expect(format!("Duplicate definition of module: {}", module_name).as_str());
+            .unwrap_or_else(|_| panic!("Duplicate definition of module: {module_name}"));
     }
 
     parameters_map
@@ -223,4 +252,437 @@ pub fn extract_modules_from_value(value: &Value) -> Result<Vec<String>, Box<dyn 
 pub fn extract_modules(cfg: &crate::SlangConfig) -> Result<Vec<String>, Box<dyn Error>> {
     let result = crate::run_slang(cfg)?;
     extract_modules_from_value(&result)
+}
+
+/// Expands the address-based type links emitted by Slang v10 and newer back
+/// into the self-contained textual format consumed by this crate's type parser.
+///
+/// Slang links have the form `<address> <display-name>`, where `<address>`
+/// matches an `addr` property elsewhere in the same AST. The display name is
+/// significant: it carries the user-visible typedef name, package qualification,
+/// and any dimensions applied at the use site. The referenced node contains the
+/// underlying definition.
+///
+/// A resolver borrows the AST because its address index stores references to
+/// nodes in that document. Construct one resolver per AST and reuse it for all
+/// type fields extracted from that AST.
+pub(crate) struct TypeResolver<'a> {
+    /// Every JSON object with an `addr` property, keyed by that Slang address.
+    by_address: HashMap<u64, &'a Value>,
+    /// Finds links both at the start of a type and nested within another type.
+    link_pattern: Regex,
+}
+
+impl<'a> TypeResolver<'a> {
+    /// Builds an address index for all objects reachable from `root`.
+    ///
+    /// Slang links are not necessarily local to the design node being examined;
+    /// a type use can refer to a definition elsewhere in the document. Indexing
+    /// the entire document up front makes subsequent resolution deterministic.
+    pub(crate) fn new(root: &'a Value) -> Self {
+        let mut by_address = HashMap::new();
+        Self::index(root, &mut by_address);
+        Self {
+            by_address,
+            link_pattern: Regex::new(
+                r"(?P<addr>[0-9]+) (?P<name>[A-Za-z_$][A-Za-z0-9_$:.]*(?:\[[^\]]+\])*(?:\$(?:\[[^\]]+\])*)?)",
+            )
+            .unwrap(),
+        }
+    }
+
+    /// Follows an address link to a structured AST node when Slang has replaced
+    /// the inline object with a string such as `"123456 module_name"`.
+    ///
+    /// Instance bodies are shared this way in Slang v11. Inline objects from
+    /// older Slang releases are returned unchanged, as are malformed or unknown
+    /// links, so callers retain the pre-v11 behavior for those inputs.
+    pub(crate) fn resolve_node(&self, value: &'a Value) -> &'a Value {
+        let Some(address) = value
+            .as_str()
+            .and_then(|link| link.split_whitespace().next())
+            .and_then(|address| address.parse::<u64>().ok())
+        else {
+            return value;
+        };
+        self.by_address.get(&address).copied().unwrap_or(value)
+    }
+
+    /// Recursively records addressable objects without making assumptions about
+    /// which AST scopes can contain type definitions.
+    fn index(value: &'a Value, by_address: &mut HashMap<u64, &'a Value>) {
+        match value {
+            Value::Object(object) => {
+                if let Some(address) = object.get("addr").and_then(Value::as_u64) {
+                    by_address.insert(address, value);
+                }
+                for child in object.values() {
+                    Self::index(child, by_address);
+                }
+            }
+            Value::Array(array) => {
+                for child in array {
+                    Self::index(child, by_address);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Expands every resolvable Slang link in a textual type definition.
+    ///
+    /// Resolution is iterative because replacing an outer typedef link can
+    /// expose more links inside its target. Unknown addresses and unsupported
+    /// node kinds are preserved verbatim so the normal type parser can report
+    /// an informative error (or the caller can skip unsupported types).
+    pub(crate) fn resolve(&self, type_text: &str) -> String {
+        let mut result = type_text.to_string();
+        // Cap expansion to guard against malformed or cyclic linked typedefs.
+        for _ in 0..64 {
+            let replaced = self
+                .link_pattern
+                .replace_all(&result, |captures: &regex::Captures| {
+                    let address = captures["addr"].parse::<u64>().unwrap();
+                    self.render_link(address, &captures["name"])
+                        .unwrap_or_else(|| captures[0].to_string())
+                })
+                .into_owned();
+            if replaced == result {
+                return result;
+            }
+            result = replaced;
+        }
+        result
+    }
+
+    /// Resolves a `TypeAlias` node that appears directly in a package.
+    ///
+    /// Direct package members are definitions rather than address-link use
+    /// sites, so Slang does not repeat the public alias name in `target`. Pass
+    /// that name explicitly to replace any generated aggregate name while
+    /// preserving the same behavior as an ordinary linked alias.
+    pub(crate) fn resolve_alias(&self, node: &Value, display_name: &str) -> Option<String> {
+        let target = self.resolve(node.get("target")?.as_str()?);
+        self.render_alias_target(&target, display_name)
+    }
+
+    /// Renders one linked definition using the name and dimensions from its use
+    /// site rather than the serializer's internal generated name.
+    fn render_link(&self, address: u64, display_name: &str) -> Option<String> {
+        let node = *self.by_address.get(&address)?;
+        match node.get("kind").and_then(Value::as_str)? {
+            "TypeAlias" => self.resolve_alias(node, display_name),
+            "EnumType" => self.render_enum(node, display_name),
+            _ => None,
+        }
+    }
+
+    /// Applies a typedef's public name and use-site dimensions to its resolved
+    /// target text.
+    fn render_alias_target(&self, target: &str, display_name: &str) -> Option<String> {
+        let display_dimension_start = dimension_start(display_name);
+        let display_dimensions = display_dimension_start
+            .map(|index| &display_name[index..])
+            .unwrap_or("");
+        let display_name = display_dimension_start
+            .map(|index| &display_name[..index])
+            .unwrap_or(display_name);
+        if matches!(
+            target.split_once('{').map(|(prefix, _)| prefix.trim()),
+            Some("struct")
+                | Some("struct packed")
+                | Some("union")
+                | Some("union packed")
+                | Some("enum")
+        ) {
+            // Aggregate targets end in an internal nominal name. Replace it
+            // with the package-qualified name from this use site. Dimensions
+            // after the target's internal name belong to the typedef itself and
+            // must precede dimensions applied at this particular use site.
+            let close = target.rfind('}')?;
+            let target_suffix = &target[close + 1..];
+            let target_dimensions = dimension_start(target_suffix)
+                .map(|index| &target_suffix[index..])
+                .unwrap_or("");
+            Some(format!(
+                "{}{display_name}{}",
+                &target[..=close],
+                merge_dimensions(target_dimensions, display_dimensions)
+            ))
+        } else {
+            let target_dimension_start = dimension_start(target);
+            let target_dimensions = target_dimension_start
+                .map(|index| &target[index..])
+                .unwrap_or("");
+            let target = target_dimension_start
+                .map(|index| &target[..index])
+                .unwrap_or(target);
+            Some(format!(
+                "{target}{}",
+                merge_dimensions(target_dimensions, display_dimensions)
+            ))
+        }
+    }
+
+    /// Reconstructs the legacy textual enum syntax from a v10+ `EnumType` node.
+    ///
+    /// Unlike struct and union aliases, Slang no longer leaves a complete enum
+    /// declaration in a string that can simply be followed. Its members and
+    /// values must therefore be rendered from the structured JSON node.
+    fn render_enum(&self, node: &Value, display_name: &str) -> Option<String> {
+        let members = node.get("members")?.as_array()?;
+        let variants = members
+            .iter()
+            .filter(|member| member.get("kind").and_then(Value::as_str) == Some("EnumValue"))
+            .map(|member| {
+                let name = member.get("name")?.as_str()?;
+                let value = member.get("value")?.as_str()?;
+                let (width, signed, magnitude) = parse_integer_literal(value)?;
+                let sign = if magnitude.sign() == num_bigint::Sign::Minus {
+                    "-"
+                } else {
+                    ""
+                };
+                let signed = if signed { "s" } else { "" };
+                Some(format!(
+                    "{name}={sign}{width}'{signed}d{}",
+                    magnitude.magnitude()
+                ))
+            })
+            .collect::<Option<Vec<_>>>()?
+            .join(",");
+        Some(format!("enum{{{variants}}}{display_name}"))
+    }
+}
+
+/// Finds the first packed (`[... ]`) or unpacked (`$[...]`) dimension.
+///
+/// Slang's generated nominal type names can themselves contain `$`, so only
+/// `$[` marks an unpacked dimension boundary.
+fn dimension_start(type_name: &str) -> Option<usize> {
+    match (type_name.find('['), type_name.find("$[")) {
+        (Some(packed), Some(unpacked)) => Some(packed.min(unpacked)),
+        (Some(packed), None) => Some(packed),
+        (None, Some(unpacked)) => Some(unpacked),
+        (None, None) => None,
+    }
+}
+
+/// Combines typedef and use-site dimensions into the parser's canonical form.
+///
+/// Slang writes a `$` before each independently serialized set of unpacked
+/// dimensions. Once nested aliases are expanded there must instead be one `$`
+/// separating all packed dimensions from all unpacked dimensions.
+fn merge_dimensions(target: &str, display: &str) -> String {
+    fn split(dimensions: &str) -> (&str, &str) {
+        dimensions
+            .find("$[")
+            .map(|index| (&dimensions[..index], &dimensions[index + 1..]))
+            .unwrap_or((dimensions, ""))
+    }
+
+    let (target_packed, target_unpacked) = split(target);
+    let (display_packed, display_unpacked) = split(display);
+    let unpacked = format!("{target_unpacked}{display_unpacked}");
+    let separator = if unpacked.is_empty() { "" } else { "$" };
+    format!("{target_packed}{display_packed}{separator}{unpacked}")
+}
+
+/// Parses a SystemVerilog integer emitted by Slang.
+///
+/// The AST can use binary, octal, decimal, or hexadecimal digits, while the
+/// existing enum grammar expects decimal text. Signed bit patterns are converted
+/// from their fixed-width two's-complement representation before rendering.
+/// Slang v11 can also emit unsized enum values as plain decimal strings; these
+/// have SystemVerilog's default signed 32-bit integer representation.
+fn parse_integer_literal(value: &str) -> Option<(usize, bool, BigInt)> {
+    let Some((width, digits)) = value.split_once('\'') else {
+        let digits = value.replace('_', "");
+        return Some((32, true, BigInt::from_str_radix(&digits, 10).ok()?));
+    };
+    let (negative, width) = match width.strip_prefix('-') {
+        Some(width) => (true, width),
+        None => (false, width),
+    };
+    let width = width.parse::<usize>().ok()?;
+    let (signed, radix_char, digits) = if let Some(rest) = digits.strip_prefix('s') {
+        (true, rest.chars().next()?, &rest[1..])
+    } else {
+        (false, digits.chars().next()?, &digits[1..])
+    };
+    let radix = match radix_char {
+        'b' => 2,
+        'o' => 8,
+        'd' => 10,
+        'h' => 16,
+        _ => return None,
+    };
+    let digits = digits.replace('_', "");
+    let mut number = BigInt::from_str_radix(&digits, radix).ok()?;
+    if negative {
+        number = -number;
+    } else if signed && width > 0 && number.bit((width - 1) as u64) {
+        number -= BigInt::from(1u8) << width;
+    }
+    Some((width, signed, number))
+}
+
+#[cfg(test)]
+mod resolver_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn resolves_slang_v11_typedef_and_enum_links() {
+        let ast = json!({
+            "nodes": [
+                {
+                    "name": "bus_t",
+                    "kind": "TypeAlias",
+                    "addr": 100,
+                    "target": "struct packed{logic[7:0] data;logic valid;}generated$1"
+                },
+                {
+                    "name": "color_t",
+                    "kind": "EnumType",
+                    "addr": 200,
+                    "members": [
+                        { "name": "RED", "kind": "EnumValue", "value": "2'b0" },
+                        { "name": "BLUE", "kind": "EnumValue", "value": "2'b10" }
+                    ]
+                }
+            ]
+        });
+        let resolver = TypeResolver::new(&ast);
+
+        assert_eq!(
+            resolver.resolve("100 bus_t[3:0]"),
+            "struct packed{logic[7:0] data;logic valid;}bus_t[3:0]"
+        );
+        assert_eq!(
+            resolver.resolve_alias(&ast["nodes"][0], "pkg::bus_t"),
+            Some("struct packed{logic[7:0] data;logic valid;}pkg::bus_t".to_string())
+        );
+        assert_eq!(
+            resolver.resolve("200 pkg::color_t"),
+            "enum{RED=2'd0,BLUE=2'd2}pkg::color_t"
+        );
+    }
+
+    #[test]
+    fn resolves_nested_slang_v11_typedef_links() {
+        let ast = json!({
+            "nodes": [
+                {
+                    "kind": "TypeAlias",
+                    "addr": 100,
+                    "target": "struct packed{logic[7:0] data;}generated$1"
+                },
+                {
+                    "kind": "TypeAlias",
+                    "addr": 200,
+                    "target": "struct packed{100 inner_t value;}generated$2"
+                },
+                {
+                    "kind": "TypeAlias",
+                    "addr": 300,
+                    "target": "100 inner_t[3:0]"
+                },
+                {
+                    "kind": "TypeAlias",
+                    "addr": 400,
+                    "target": "logic$[3:0]"
+                },
+                {
+                    "kind": "TypeAlias",
+                    "addr": 500,
+                    "target": "400 unpacked_t$[1:0]"
+                }
+            ]
+        });
+        let resolver = TypeResolver::new(&ast);
+
+        assert_eq!(
+            resolver.resolve("200 outer_t"),
+            "struct packed{struct packed{logic[7:0] data;}inner_t value;}outer_t"
+        );
+        assert_eq!(
+            resolver.resolve("300 outer_array_t[1:0]"),
+            "struct packed{logic[7:0] data;}outer_array_t[3:0][1:0]"
+        );
+        assert_eq!(resolver.resolve("400 unpacked_t$[1:0]"), "logic$[3:0][1:0]");
+        assert!(parse_type_definition(&resolver.resolve("400 unpacked_t$[1:0]")).is_ok());
+        assert_eq!(resolver.resolve("500 nested_t"), "logic$[3:0][1:0]");
+    }
+
+    #[test]
+    fn resolves_slang_v11_dotted_scope_qualified_links() {
+        let ast = json!({
+            "nodes": [{
+                "kind": "TypeAlias",
+                "addr": 100,
+                "target": "struct packed{logic[7:0] data;}generated$1"
+            }]
+        });
+        let resolver = TypeResolver::new(&ast);
+        let resolved = resolver.resolve("100 top.byte_t");
+
+        assert_eq!(resolved, "struct packed{logic[7:0] data;}top.byte_t");
+        assert!(parse_type_definition(&resolved).is_ok());
+    }
+
+    #[test]
+    fn resolves_slang_v11_linked_instance_bodies() {
+        let ast = json!({
+            "design": {
+                "members": [
+                    {
+                        "kind": "InstanceBody",
+                        "addr": 100,
+                        "members": [
+                            {
+                                "kind": "Port",
+                                "name": "data",
+                                "direction": "In",
+                                "type": "logic[7:0]"
+                            },
+                            {
+                                "kind": "Parameter",
+                                "name": "WIDTH",
+                                "type": "int"
+                            }
+                        ]
+                    },
+                    { "kind": "Instance", "name": "top", "body": "100 top" }
+                ]
+            }
+        });
+
+        let ports = extract_ports_from_value(&ast, false);
+        assert_eq!(ports["top"][0].name, "data");
+        let parameters = extract_parameter_defs_from_value(&ast, false);
+        assert_eq!(parameters["top"][0].name, "WIDTH");
+    }
+
+    #[test]
+    fn resolves_slang_v11_unsized_enum_values() {
+        let ast = json!({
+            "nodes": [{
+                "name": "offset_t",
+                "kind": "EnumType",
+                "addr": 100,
+                "members": [
+                    { "name": "ZERO", "kind": "EnumValue", "value": "0" },
+                    { "name": "NEGATIVE", "kind": "EnumValue", "value": "-1" },
+                    { "name": "NEGATIVE_SIZED", "kind": "EnumValue", "value": "-16'sd1" }
+                ]
+            }]
+        });
+        let resolver = TypeResolver::new(&ast);
+
+        assert_eq!(
+            resolver.resolve("100 offset_t"),
+            "enum{ZERO=32'sd0,NEGATIVE=-32'sd1,NEGATIVE_SIZED=-16'sd1}offset_t"
+        );
+    }
 }

--- a/src/extract/grammar.pest
+++ b/src/extract/grammar.pest
@@ -4,7 +4,7 @@ WHITESPACE = _{ " " | "\t" | "\n" | "\r" }
 
 identifier = @{ (ASCII_ALPHANUMERIC | "_")+ }
 
-full_identifier = @{ (ASCII_ALPHANUMERIC | "_" | ":" | "$")+ }
+full_identifier = @{ (ASCII_ALPHANUMERIC | "_" | ":" | "." | "$")+ }
 
 negative_sign = { "-" }
 

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -22,16 +22,25 @@ pub fn extract_hierarchy(
 
 pub fn extract_hierarchy_from_value(value: &Value) -> HashMap<String, Instance> {
     let mut top_level_instances = HashMap::new();
+    let symbols = AstSymbols::new(value);
 
     if let Some(members) = value
         .get("design")
         .and_then(|v| v.get("members").and_then(|v| v.as_array()))
     {
         for member in members {
+            let member = symbols.resolve(member);
             if let Some(kind) = member.get("kind") {
                 if kind == "Instance" {
-                    if let Some((mut inst, value)) = descend_into_instance(member, "".to_string()) {
-                        extract_hierarchy_from_value_helper(&mut inst, value, "".to_string());
+                    if let Some((mut inst, value)) =
+                        descend_into_instance(member, "".to_string(), &symbols)
+                    {
+                        extract_hierarchy_from_value_helper(
+                            &mut inst,
+                            value,
+                            "".to_string(),
+                            &symbols,
+                        );
                         top_level_instances.insert(inst.def_name.clone(), inst);
                     }
                 }
@@ -42,16 +51,27 @@ pub fn extract_hierarchy_from_value(value: &Value) -> HashMap<String, Instance> 
     top_level_instances
 }
 
-fn extract_hierarchy_from_value_helper(top: &mut Instance, value: &Value, hier_prefix: String) {
+fn extract_hierarchy_from_value_helper(
+    top: &mut Instance,
+    value: &Value,
+    hier_prefix: String,
+    symbols: &AstSymbols,
+) {
     let symbol_table = create_symbol_table(value);
     if let Some(members) = value.get("members").and_then(|v| v.as_array()) {
         for member in members {
+            let member = symbols.resolve(member);
             if let Some(kind) = member.get("kind") {
                 if kind == "Instance" {
                     if let Some((mut inst, value)) =
-                        descend_into_instance(member, hier_prefix.clone())
+                        descend_into_instance(member, hier_prefix.clone(), symbols)
                     {
-                        extract_hierarchy_from_value_helper(&mut inst, value, "".to_string());
+                        extract_hierarchy_from_value_helper(
+                            &mut inst,
+                            value,
+                            "".to_string(),
+                            symbols,
+                        );
                         top.contents.push(Rc::new(RefCell::new(inst)));
                     }
                 } else if kind == "UninstantiatedDef" {
@@ -71,7 +91,12 @@ fn extract_hierarchy_from_value_helper(top: &mut Instance, value: &Value, hier_p
                     if let Some((hier_prefix, value)) =
                         descend_into_generate_block(member, hier_prefix.clone(), &symbol_table)
                     {
-                        extract_hierarchy_from_value_helper(top, value, hier_prefix.clone());
+                        extract_hierarchy_from_value_helper(
+                            top,
+                            value,
+                            hier_prefix.clone(),
+                            symbols,
+                        );
                     }
                 } else if kind == "GenerateBlockArray" {
                     if let Some(elements) = descend_into_generate_block_array(
@@ -80,7 +105,12 @@ fn extract_hierarchy_from_value_helper(top: &mut Instance, value: &Value, hier_p
                         &symbol_table,
                     ) {
                         for (hier_prefix, element) in elements {
-                            extract_hierarchy_from_value_helper(top, element, hier_prefix.clone());
+                            extract_hierarchy_from_value_helper(
+                                top,
+                                element,
+                                hier_prefix.clone(),
+                                symbols,
+                            );
                         }
                     }
                 }
@@ -89,12 +119,16 @@ fn extract_hierarchy_from_value_helper(top: &mut Instance, value: &Value, hier_p
     }
 }
 
-fn descend_into_instance(value: &Value, hier_prefix: String) -> Option<(Instance, &Value)> {
+fn descend_into_instance<'a>(
+    value: &'a Value,
+    hier_prefix: String,
+    symbols: &AstSymbols<'a>,
+) -> Option<(Instance, &'a Value)> {
     if let Some(inst_name) = value.get("name").and_then(|v| v.as_str()) {
         if inst_name.is_empty() {
             return None;
         }
-        if let Some(body) = value.get("body") {
+        if let Some(body) = value.get("body").map(|body| symbols.resolve(body)) {
             if let Some(def_name) = body.get("name").and_then(|v| v.as_str()) {
                 if def_name.is_empty() {
                     return None;
@@ -113,6 +147,58 @@ fn descend_into_instance(value: &Value, hier_prefix: String) -> Option<(Instance
     }
 
     None
+}
+
+/// Resolves Slang AST links. Slang v10 and newer serialize a node only once and
+/// represent subsequent references as strings containing the node address and
+/// name (for example, `"123456 C"`). Older releases serialize those nodes
+/// inline, so accepting both forms keeps this crate compatible across versions.
+struct AstSymbols<'a> {
+    /// Every serialized AST object that can be the target of an address link.
+    by_address: HashMap<u64, &'a Value>,
+}
+
+impl<'a> AstSymbols<'a> {
+    /// Indexes the complete JSON document so links can cross AST scopes.
+    fn new(root: &'a Value) -> Self {
+        let mut by_address = HashMap::new();
+        Self::index(root, &mut by_address);
+        Self { by_address }
+    }
+
+    /// Recursively records each object with an `addr` field.
+    fn index(value: &'a Value, by_address: &mut HashMap<u64, &'a Value>) {
+        match value {
+            Value::Object(object) => {
+                if let Some(address) = object.get("addr").and_then(Value::as_u64) {
+                    by_address.insert(address, value);
+                }
+                for child in object.values() {
+                    Self::index(child, by_address);
+                }
+            }
+            Value::Array(array) => {
+                for child in array {
+                    Self::index(child, by_address);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Follows a v10+ string link to its serialized object.
+    ///
+    /// Inline objects from older Slang releases are returned unchanged. An
+    /// unknown or malformed link is also left untouched, allowing the caller's
+    /// existing shape checks to reject it naturally.
+    fn resolve(&self, value: &'a Value) -> &'a Value {
+        value
+            .as_str()
+            .and_then(|link| link.split_whitespace().next())
+            .and_then(|address| address.parse::<u64>().ok())
+            .and_then(|address| self.by_address.get(&address).copied())
+            .unwrap_or(value)
+    }
 }
 
 fn descend_into_generate_block<'a>(
@@ -195,4 +281,42 @@ fn get_default_genblk_name(index: usize, symbol_table: &HashSet<String>) -> Stri
         prefix = format!("{prefix}0");
     }
     format!("{prefix}{index}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn resolves_repeated_instance_body_links_from_slang_v11() {
+        let ast = json!({
+            "design": {
+                "members": [{
+                    "name": "top",
+                    "kind": "Instance",
+                    "body": {
+                        "name": "top",
+                        "kind": "InstanceBody",
+                        "addr": 1,
+                        "members": [
+                            {
+                                "name": "first",
+                                "kind": "Instance",
+                                "body": { "name": "child", "kind": "InstanceBody", "addr": 2 }
+                            },
+                            { "name": "second", "kind": "Instance", "body": "2 child" }
+                        ]
+                    }
+                }]
+            }
+        });
+
+        let hierarchy = extract_hierarchy_from_value(&ast);
+        let children = &hierarchy["top"].contents;
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0].borrow().inst_name, "first");
+        assert_eq!(children[1].borrow().inst_name, "second");
+        assert_eq!(children[1].borrow().def_name, "child");
+    }
 }

--- a/src/package.rs
+++ b/src/package.rs
@@ -76,6 +76,7 @@ pub fn extract_packages(
 
 pub fn extract_packages_from_value(value: &Value) -> HashMap<String, Package> {
     let mut packages = HashMap::new();
+    let type_resolver = crate::extract::TypeResolver::new(value);
 
     if let Some(members) = value
         .get("design")
@@ -84,7 +85,7 @@ pub fn extract_packages_from_value(value: &Value) -> HashMap<String, Package> {
         for member in members {
             if let Some(kind) = member.get("kind") {
                 if kind == "CompilationUnit" {
-                    extract_packages_from_compilation_unit(member, &mut packages);
+                    extract_packages_from_compilation_unit(member, &mut packages, &type_resolver);
                 }
             }
         }
@@ -93,7 +94,11 @@ pub fn extract_packages_from_value(value: &Value) -> HashMap<String, Package> {
     packages
 }
 
-fn extract_packages_from_compilation_unit(value: &Value, packages: &mut HashMap<String, Package>) {
+fn extract_packages_from_compilation_unit(
+    value: &Value,
+    packages: &mut HashMap<String, Package>,
+    type_resolver: &crate::extract::TypeResolver,
+) {
     if let Some(members) = value.get("members").and_then(|v| v.as_array()) {
         for member in members {
             if let Some(kind) = member.get("kind") {
@@ -113,7 +118,9 @@ fn extract_packages_from_compilation_unit(value: &Value, packages: &mut HashMap<
                                                 .insert(parameter.name.clone(), parameter);
                                         }
                                     } else if kind == "TypeAlias" {
-                                        if let Some(type_alias) = process_type_alias(member) {
+                                        if let Some(type_alias) =
+                                            process_type_alias(member, type_resolver)
+                                        {
                                             package
                                                 .parameters
                                                 .insert(type_alias.name.clone(), type_alias);
@@ -142,12 +149,17 @@ fn process_parameter(member: &Value) -> Option<Parameter> {
     None
 }
 
-fn process_type_alias(member: &Value) -> Option<Parameter> {
+fn process_type_alias(
+    member: &Value,
+    type_resolver: &crate::extract::TypeResolver,
+) -> Option<Parameter> {
     if let Some(target) = member.get("target").and_then(|v| v.as_str()) {
         if let Some(name) = member.get("name").and_then(|v| v.as_str()) {
             return Some(Parameter {
                 name: name.to_string(),
-                value: target.to_string(),
+                value: type_resolver
+                    .resolve_alias(member, name)
+                    .unwrap_or_else(|| type_resolver.resolve(target)),
             });
         }
     }


### PR DESCRIPTION
# Problem

slang-rs targets an older Slang AST JSON format and documents Slang 6.0, while the current supported Slang release is 11.0. Slang 10 and newer deduplicate repeated AST nodes and types using address-based links, which breaks hierarchy, typedef, enum, struct, union, package, and array extraction in the existing parser.

# Solution

Update the pinned Slang release and installation documentation to 11.0. Resolve address-linked AST nodes and reconstruct linked type definitions before parsing them, while preserving compatibility with older inline AST data. Add focused regression tests for linked types, nested aliases, inherited dimensions, and repeated instance bodies, and bump the crate to 0.22.0.
